### PR TITLE
Additional optimizations for the GPU usage of smoke

### DIFF
--- a/src/deco-effects.cpp
+++ b/src/deco-effects.cpp
@@ -1,819 +1,17 @@
 #include <wayfire/debug.hpp>
 
 #include "deco-effects.hpp"
+#include "smoke-shaders.hpp"
 
 
 namespace wf
 {
 namespace pixdecor
 {
-static const char *motion_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 3) uniform int px;
-layout(location = 4) uniform int py;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 7) uniform int rand1;
-layout(location = 8) uniform int rand2;
-layout(location = 9) uniform int radius;
-
-void motion(int x, int y)
+static std::string stitch_smoke_shader(const std::string& source)
 {
-	int i, i0, i1, j, j0, j1, d = 2;
-
-	if (x - d < 1)
-		i0 = 1;
-	else
-		i0 = x - d;
-	if (i0 + 2 * d > width - 1)
-		i1 = width - 1;
-	else
-		i1 = i0 + 2 * d;
-
-	if (y - d < 1)
-		j0 = 1;
-	else
-		j0 = y - d;
-	if (j0 + 2 * d > height - 1)
-		j1 = height - 1;
-	else
-		j1 = j0 + 2 * d;
-
-	for (i = i0; i < i1; i++)
-	{
-		for (j = j0; j < j1; j++) {
-			if (i < radius || j < radius || i > (width - 1) - radius || j > (height - 1) - radius || (i > border_size && i < (width - 1) - border_size && j > (title_height - 1) && j < (height - 1) - border_size))
-			{
-				continue;
-			}
-			vec4 b0u = imageLoad(in_b0u, ivec2(i, j));
-			vec4 b0v = imageLoad(in_b0v, ivec2(i, j));
-			vec4 b0d = imageLoad(in_b0d, ivec2(i, j));
-			float u = b0u.x;
-			float v = b0v.x;
-			float d = b0d.x;
-			imageStore(out_b0u, ivec2(i, j), vec4(u + float(256 - (rand1 & 512)), 0.0, 0.0, 0.0));
-			imageStore(out_b0v, ivec2(i, j), vec4(v + float(256 - (rand2 & 512)), 0.0, 0.0, 0.0));
-			imageStore(out_b0d, ivec2(i, j), vec4(d + 1.0, 0.0, 0.0, 0.0));
-		}
-	}
+    return smoke_header + source + effect_run_for_region_main;
 }
-
-void main()
-{
-    motion(px, py);
-}
-)";
-
-static const char *diffuse1_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void diffuse1(int x, int y)
-{
-	int k, stride;
-	float t, a = 0.0002;
-
-	stride = width;
-
-	if (x < (radius == 0 ? 1 : radius) || y < (radius == 0 ? 1 : radius) || x > (width - 1) - (radius == 0 ? 1 : radius) || y > (height - 1) - (radius == 0 ? 1 : radius) ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s = imageLoad(in_b0u, ivec2(x, y));
-	vec4 d1 = imageLoad(in_b1u, ivec2(x - 1, y));
-	vec4 d2 = imageLoad(in_b1u, ivec2(x + 1, y));
-	vec4 d3 = imageLoad(in_b1u, ivec2(x, y - 1));
-	vec4 d4 = imageLoad(in_b1u, ivec2(x, y + 1));
-	float sx = s.x;
-	float du1 = d1.x;
-	float du2 = d2.x;
-	float du3 = d3.x;
-	float du4 = d4.x;
-	float t1 = du1 + du2 + du3 + du4;
-	s = imageLoad(in_b0v, ivec2(x, y));
-	d1 = imageLoad(in_b1v, ivec2(x - 1, y));
-	d2 = imageLoad(in_b1v, ivec2(x + 1, y));
-	d3 = imageLoad(in_b1v, ivec2(x, y - 1));
-	d4 = imageLoad(in_b1v, ivec2(x, y + 1));
-	float sy = s.x;
-	du1 = d1.x;
-	du2 = d2.x;
-	du3 = d3.x;
-	du4 = d4.x;
-	float t2 = du1 + du2 + du3 + du4;
-	imageStore(out_b1u, ivec2(x, y), vec4((sx + a * t1) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
-	imageStore(out_b1v, ivec2(x, y), vec4((sy + a * t2) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    diffuse1(pos.x, pos.y);
-}
-)";
-
-static const char *project1_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void project1(int x, int y)
-{
-	int k, l, s;
-	float h;
-
-	h = 1.0 / float(width);
-	s = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
-	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
-	vec4 s3 = imageLoad(in_b1v, ivec2(x, y - 1));
-	vec4 s4 = imageLoad(in_b1v, ivec2(x, y + 1));
-	float u1 = s1.x;
-	float u2 = s2.x;
-	float v1 = s3.x;
-	float v2 = s4.x;
-	imageStore(out_b0u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
-	imageStore(out_b0v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    project1(pos.x, pos.y);
-}
-)";
-
-static const char *project2_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void project2(int x, int y)
-{
-	int k, l, s;
-	float h;
-
-	h = 1.0 / float(width);
-	s = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s0 = imageLoad(in_b0v, ivec2(x, y));
-	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
-	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
-	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
-	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
-	float u1 = s1.x;
-	float u2 = s2.x;
-	float u3 = s3.x;
-	float u4 = s4.x;
-	imageStore(out_b0u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    project2(pos.x, pos.y);
-}
-)";
-
-static const char *project3_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void project3(int x, int y)
-{
-	int k, l, s;
-	float h;
-
-	h = 1.0 / float(width);
-	s = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s0x = imageLoad(in_b1u, ivec2(x, y));
-	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
-	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
-	vec4 s0y = imageLoad(in_b1v, ivec2(x, y));
-	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
-	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
-	float su = s0x.x;
-	float u1 = s1.x;
-	float u2 = s2.x;
-	float sv = s0y.x;
-	float u3 = s3.x;
-	float u4 = s4.x;
-	imageStore(out_b1u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
-	imageStore(out_b1v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    project3(pos.x, pos.y);
-}
-)";
-
-static const char *advect1_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void advect1(int x, int y) /* b1.u, b1.v, b1.u, b0.u */
-{
-	int stride;
-	int i, j;
-	float fx, fy;
-
-	stride = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 sx = imageLoad(in_b1u, ivec2(x, y));
-	vec4 sy = imageLoad(in_b1v, ivec2(x, y));
-	float ix = float(x) - sx.x;
-	float iy = float(y) - sy.x;
-	if (ix < 0.5)
-		ix = 0.5;
-	if (iy < 0.5)
-		iy = 0.5;
-	if (ix > float(width) - 1.5)
-		ix = float(width) - 1.5;
-	if (iy > float(height) - 1.5)
-		iy = float(height) - 1.5;
-	i = int(ix);
-	j = int(iy);
-	fx = ix - float(i);
-	fy = iy - float(j);
-	vec4 s0x = imageLoad(in_b1u, ivec2(i,     j));
-	vec4 s1x = imageLoad(in_b1u, ivec2(i + 1, j));
-	vec4 s2x = imageLoad(in_b1u, ivec2(i,     j + 1));
-	vec4 s3x = imageLoad(in_b1u, ivec2(i + 1, j + 1));
-	float p1 = (s0x.x * (1.0 - fx) + s1x.x * fx) * (1.0 - fy) + (s2x.x * (1.0 - fx) + s3x.x * fx) * fy;
-	imageStore(out_b0u, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
-	ix = float(x) - sx.x;
-	iy = float(y) - sy.x;
-	if (ix < 0.5)
-		ix = 0.5;
-	if (iy < 0.5)
-		iy = 0.5;
-	if (ix > float(width) - 1.5)
-		ix = float(width) - 1.5;
-	if (iy > float(height) - 1.5)
-		iy = float(height) - 1.5;
-	i = int(ix);
-	j = int(iy);
-	fx = ix - float(i);
-	fy = iy - float(j);
-	vec4 s0y = imageLoad(in_b1v, ivec2(i,     j));
-	vec4 s1y = imageLoad(in_b1v, ivec2(i + 1, j));
-	vec4 s2y = imageLoad(in_b1v, ivec2(i,     j + 1));
-	vec4 s3y = imageLoad(in_b1v, ivec2(i + 1, j + 1));
-	float p2 = (s0y.x * (1.0 - fx) + s1y.x * fx) * (1.0 - fy) + (s2y.x * (1.0 - fx) + s3y.x * fx) * fy;
-	imageStore(out_b0v, ivec2(x, y), vec4(p2, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    advect1(pos.x, pos.y);
-}
-)";
-
-static const char *project4_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void project4(int x, int y)
-{
-	int k, l, s;
-	float h;
-
-	h = 1.0 / float(width);
-	s = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
-	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
-	vec4 s3 = imageLoad(in_b0v, ivec2(x, y - 1));
-	vec4 s4 = imageLoad(in_b0v, ivec2(x, y + 1));
-	float u1 = s1.x;
-	float u2 = s2.x;
-	float v1 = s3.x;
-	float v2 = s4.x;
-	imageStore(out_b1u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
-	imageStore(out_b1v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    project4(pos.x, pos.y);
-}
-)";
-
-static const char *project5_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void project5(int x, int y)
-{
-	int k, l, s;
-	float h;
-
-	h = 1.0 / float(width);
-	s = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s0 = imageLoad(in_b1v, ivec2(x, y));
-	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
-	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
-	vec4 s3 = imageLoad(in_b1u, ivec2(x, y - 1));
-	vec4 s4 = imageLoad(in_b1u, ivec2(x, y + 1));
-	float u1 = s1.x;
-	float u2 = s2.x;
-	float u3 = s3.x;
-	float u4 = s4.x;
-	imageStore(out_b1u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    project5(pos.x, pos.y);
-}
-)";
-
-static const char *project6_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void project6(int x, int y)
-{
-	int k, l, s;
-	float h;
-
-	h = 1.0 / float(width);
-	s = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s0x = imageLoad(in_b0u, ivec2(x, y));
-	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
-	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
-	vec4 s0y = imageLoad(in_b0v, ivec2(x, y));
-	vec4 s3 = imageLoad(in_b1u, ivec2(x, y - 1));
-	vec4 s4 = imageLoad(in_b1u, ivec2(x, y + 1));
-	float su = s0x.x;
-	float u1 = s1.x;
-	float u2 = s2.x;
-	float sv = s0y.x;
-	float u3 = s3.x;
-	float u4 = s4.x;
-	imageStore(out_b0u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
-	imageStore(out_b0v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    project6(pos.x, pos.y);
-}
-)";
-
-static const char *diffuse2_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void diffuse2(int x, int y)
-{
-	int k, stride;
-	float t, a = 0.0002;
-
-	stride = width;
-
-	if (x < (radius == 0 ? 1 : radius) || y < (radius == 0 ? 1 : radius) || x > (width - 1) - (radius == 0 ? 1 : radius) || y > (height - 1) - (radius == 0 ? 1 : radius) ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s = imageLoad(in_b0d, ivec2(x, y));
-	vec4 d1 = imageLoad(in_b1d, ivec2(x - 1, y));
-	vec4 d2 = imageLoad(in_b1d, ivec2(x + 1, y));
-	vec4 d3 = imageLoad(in_b1d, ivec2(x, y - 1));
-	vec4 d4 = imageLoad(in_b1d, ivec2(x, y + 1));
-	float sz = s.x;
-	float du1 = d1.x;
-	float du2 = d2.x;
-	float du3 = d3.x;
-	float du4 = d4.x;
-	t = du1 + du2 + du3 + du4;
-	imageStore(out_b1d, ivec2(x, y), vec4((sz + a * t) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    diffuse2(pos.x, pos.y);
-}
-)";
-
-static const char *advect2_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 1, r32f) uniform readonly image2D in_b0u;
-layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
-layout (binding = 2, r32f) uniform readonly image2D in_b0v;
-layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
-layout (binding = 4, r32f) uniform readonly image2D in_b1u;
-layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
-layout (binding = 5, r32f) uniform readonly image2D in_b1v;
-layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
-layout (binding = 6, r32f) uniform readonly image2D in_b1d;
-layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 9) uniform int radius;
-
-void advect2(int x, int y) /*b0u, b0v, b1d, b0d*/
-{
-	int stride;
-	int i, j;
-	float fx, fy;
-
-	stride = width;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 sx = imageLoad(in_b0u, ivec2(x, y));
-	vec4 sy = imageLoad(in_b0v, ivec2(x, y));
-	float ix = float(x) - sx.x;
-	float iy = float(y) - sy.x;
-	if (ix < 0.5)
-		ix = 0.5;
-	if (iy < 0.5)
-		iy = 0.5;
-	if (ix > float(width) - 1.5)
-		ix = float(width) - 1.5;
-	if (iy > float(height) - 1.5)
-		iy = float(height) - 1.5;
-	i = int(ix);
-	j = int(iy);
-	fx = ix - float(i);
-	fy = iy - float(j);
-	vec4 s0z = imageLoad(in_b1d, ivec2(i,     j));
-	vec4 s1z = imageLoad(in_b1d, ivec2(i + 1, j));
-	vec4 s2z = imageLoad(in_b1d, ivec2(i,     j + 1));
-	vec4 s3z = imageLoad(in_b1d, ivec2(i + 1, j + 1));
-	float p1 = (s0z.x * (1.0 - fx) + s1z.x * fx) * (1.0 - fy) + (s2z.x * (1.0 - fx) + s3z.x * fx) * fy;
-	imageStore(out_b0d, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    advect2(pos.x, pos.y);
-}
-)";
-
-static const char *render_source =
-    R"(
-#version 320 es
-
-precision lowp image2D;
-
-layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
-layout (binding = 3, r32f) uniform readonly image2D in_b0d;
-layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
-
-layout(location = 1) uniform int title_height;
-layout(location = 2) uniform int border_size;
-layout(location = 4) uniform bool ink;
-layout(location = 5) uniform int width;
-layout(location = 6) uniform int height;
-layout(location = 7) uniform int radius;
-layout(location = 8) uniform vec4 smoke_color;
-layout(location = 9) uniform vec4 decor_color;
-
-void render(int x, int y)
-{
-	float c, r, g, b, a;
-
-	if (x < radius || y < radius || x > (width - 1) - radius || y > (height - 1) - radius ||
-	    (x > border_size && x < (width - 1) - border_size && y > title_height && y < (height - 1) - border_size))
-	{
-		return;
-	}
-
-	vec4 s = imageLoad(in_b0d, ivec2(x, y));
-	c = s.x * 800.0;
-	if (c > 255.0)
-		c = 255.0;
-	a = c;
-	vec3 color;
-	if (ink)
-	{
-		if (c > 2.0)
-			color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
-		else
-			color = mix(decor_color.rgb, vec3(0.0, 0.0, 0.0), clamp(a, 0.0, 1.0));
-		if (c > 1.5)
-			imageStore(out_tex, ivec2(x, y), vec4(color, 1.0));
-		else
-			imageStore(out_tex, ivec2(x, y), decor_color);
-		return;
-	} else
-	{
-		color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
-	}
-	imageStore(out_tex, ivec2(x, y), vec4(color, decor_color.a));
-}
-
-void main()
-{
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-    render(pos.x, pos.y);
-}
-)";
 
 // ported from https://www.shadertoy.com/view/WdXBW4
 static const char *render_source_clouds =
@@ -2924,17 +2122,17 @@ void smoke_t::create_programs()
     if ((std::string(effect_type) == "smoke") || (std::string(effect_type) == "ink"))
     {
         setup_shader(&motion_program, motion_source);
-        setup_shader(&diffuse1_program, diffuse1_source);
-        setup_shader(&diffuse2_program, diffuse2_source);
-        setup_shader(&project1_program, project1_source);
-        setup_shader(&project2_program, project2_source);
-        setup_shader(&project3_program, project3_source);
-        setup_shader(&project4_program, project4_source);
-        setup_shader(&project5_program, project5_source);
-        setup_shader(&project6_program, project6_source);
-        setup_shader(&advect1_program, advect1_source);
-        setup_shader(&advect2_program, advect2_source);
-        setup_shader(&render_program, render_source);
+        setup_shader(&diffuse1_program, stitch_smoke_shader(diffuse1_source));
+        setup_shader(&diffuse2_program, stitch_smoke_shader(diffuse2_source));
+        setup_shader(&project1_program, stitch_smoke_shader(project1_source));
+        setup_shader(&project2_program, stitch_smoke_shader(project2_source));
+        setup_shader(&project3_program, stitch_smoke_shader(project3_source));
+        setup_shader(&project4_program, stitch_smoke_shader(project4_source));
+        setup_shader(&project5_program, stitch_smoke_shader(project5_source));
+        setup_shader(&project6_program, stitch_smoke_shader(project6_source));
+        setup_shader(&advect1_program, stitch_smoke_shader(advect1_source));
+        setup_shader(&advect2_program, stitch_smoke_shader(advect2_source));
+        setup_shader(&render_program, std::string(render_source) + effect_run_for_region_main);
     } else if (std::string(effect_type) == "clouds")
     {
         setup_shader(&render_program, render_source_clouds);
@@ -3035,6 +2233,50 @@ void smoke_t::destroy_textures()
     GL_CALL(glDeleteTextures(1, &b1d));
 
     b0u = b0v = b0d = b1u = b1v = b1d = GLuint(-1);
+}
+
+int roundUpDiv(int a, int b)
+{
+    return (a + b - 1) / b;
+}
+
+void smoke_t::dispatch_region(const wf::region_t& region)
+{
+    for (auto& box : region)
+    {
+        auto rect = wlr_box_from_pixman_box(box);
+        GL_CALL(glUniform4i(0, rect.x, rect.y, rect.width, rect.height));
+        GL_CALL(glDispatchCompute(roundUpDiv(rect.width, 16), roundUpDiv(rect.height, 16), 1));
+    }
+
+    GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
+}
+
+void smoke_t::run_shader_region(GLuint program, const wf::region_t &region, const wf::dimensions_t &size)
+{
+    GL_CALL(glUseProgram(program));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 1));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b0u));
+    GL_CALL(glBindImageTexture(1, b0u, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 2));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b0v));
+    GL_CALL(glBindImageTexture(2, b0v, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 3));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b0d));
+    GL_CALL(glBindImageTexture(3, b0d, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 4));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b1u));
+    GL_CALL(glBindImageTexture(4, b1u, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 5));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b1v));
+    GL_CALL(glBindImageTexture(5, b1v, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 6));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b1d));
+    GL_CALL(glBindImageTexture(6, b1d, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+
+    GL_CALL(glUniform1i(5, size.width));
+    GL_CALL(glUniform1i(6, size.height));
+    dispatch_region(region);
 }
 
 void smoke_t::run_shader(GLuint program, int width, int height, int title_height, int border_size, int radius)
@@ -3156,6 +2398,25 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
     GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
     GL_CALL(glBindImageTexture(0, texture, 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA32F));
 
+    const wf::geometry_t nonshadow_rect = wf::geometry_t{
+        radius * 2,
+        radius * 2,
+        rectangle.width - 4 * radius,
+        rectangle.height - 4 * radius
+    };
+
+    wf::geometry_t inner_part = {
+        border_size + radius * 2,
+        title_height + border_size + radius * 2,
+        rectangle.width - border_size * 2 - radius * 4,
+        rectangle.height - border_size * 2 - title_height - radius * 4,
+    };
+
+    wf::region_t border_region = nonshadow_rect;
+    border_region ^= inner_part;
+    border_region.expand_edges(1);
+    border_region &= nonshadow_rect;
+
     if (smoke)
     {
         wf::point_t point{int(p.x), int(p.y)};
@@ -3202,34 +2463,30 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
 
         for (int k = 0; k < diffuse_iterations; k++)
         {
-            run_shader(diffuse1_program, rectangle.width, rectangle.height, title_height, border_size,
-                radius);
+            run_shader_region(diffuse1_program, border_region, wf::dimensions(rectangle));
         }
 
-        run_shader(project1_program, rectangle.width, rectangle.height, title_height, border_size, radius);
+        run_shader_region(project1_program, border_region, wf::dimensions(rectangle));
         for (int k = 0; k < diffuse_iterations; k++)
         {
-            run_shader(project2_program, rectangle.width, rectangle.height, title_height, border_size,
-                radius);
+            run_shader_region(project2_program, border_region, wf::dimensions(rectangle));
         }
 
-        run_shader(project3_program, rectangle.width, rectangle.height, title_height, border_size, radius);
-        run_shader(advect1_program, rectangle.width, rectangle.height, title_height, border_size, radius);
-        run_shader(project4_program, rectangle.width, rectangle.height, title_height, border_size, radius);
+        run_shader_region(project3_program, border_region, wf::dimensions(rectangle));
+        run_shader_region(advect1_program, border_region, wf::dimensions(rectangle));
+        run_shader_region(project4_program, border_region, wf::dimensions(rectangle));
         for (int k = 0; k < diffuse_iterations; k++)
         {
-            run_shader(project5_program, rectangle.width, rectangle.height, title_height, border_size,
-                radius);
+            run_shader_region(project5_program, border_region, wf::dimensions(rectangle));
         }
 
-        run_shader(project6_program, rectangle.width, rectangle.height, title_height, border_size, radius);
+        run_shader_region(project6_program, border_region, wf::dimensions(rectangle));
         for (int k = 0; k < diffuse_iterations; k++)
         {
-            run_shader(diffuse2_program, rectangle.width, rectangle.height, title_height, border_size,
-                radius);
+            run_shader_region(diffuse2_program, border_region, wf::dimensions(rectangle));
         }
 
-        run_shader(advect2_program, rectangle.width, rectangle.height, title_height, border_size, radius);
+        run_shader_region(advect2_program, border_region, wf::dimensions(rectangle));
     }
 
     if (std::string(effect_type) != "none")
@@ -3241,23 +2498,24 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
             GLfloat(effect_color.a)};
         GLfloat decor_color_f[4] =
         {GLfloat(decor_color.r), GLfloat(decor_color.g), GLfloat(decor_color.b), GLfloat(decor_color.a)};
-        GL_CALL(glUniform1i(1, title_height + border_size + radius * 2));
-        GL_CALL(glUniform1i(2, border_size + radius * 2));
-        GL_CALL(glUniform1i(5, rectangle.width));
-        GL_CALL(glUniform1i(6, rectangle.height));
-        GL_CALL(glUniform1i(7, radius * 2));
         if (smoke)
         {
             GL_CALL(glUniform1i(4, ink));
             GL_CALL(glUniform4fv(8, 1, effect_color_f));
             GL_CALL(glUniform4fv(9, 1, decor_color_f));
+            dispatch_region(border_region);
         } else
         {
+            GL_CALL(glUniform1i(1, title_height + border_size + radius * 2));
+            GL_CALL(glUniform1i(2, border_size + radius * 2));
+            GL_CALL(glUniform1i(5, rectangle.width));
+            GL_CALL(glUniform1i(6, rectangle.height));
+            GL_CALL(glUniform1i(7, radius * 2));
             GL_CALL(glUniform1f(9, effect_animate ? (wf::get_current_time() / 30.0) : 0.0));
+            GL_CALL(glDispatchCompute(rectangle.width / 15, rectangle.height / 15, 1));
+            GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
         }
 
-        GL_CALL(glDispatchCompute(rectangle.width / 15, rectangle.height / 15, 1));
-        GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
     } else if (!smoke && (std::string(overlay_engine) != "none"))
     {
         GLuint fb;
@@ -3320,5 +2578,5 @@ void smoke_t::effect_updated()
     recreate_textures(wf::geometry_t{0, 0, saved_width, saved_height});
     OpenGL::render_end();
 }
-}
+} // namespace pixdecor
 }

--- a/src/deco-effects.hpp
+++ b/src/deco-effects.hpp
@@ -32,6 +32,9 @@ class smoke_t
     ~smoke_t();
 
     void run_shader(GLuint program, int width, int height, int title_height, int border_size, int radius);
+    void run_shader_region(GLuint program, const wf::region_t &region, const wf::dimensions_t &size);
+    void dispatch_region(const wf::region_t& region);
+
     void step_effect(const wf::render_target_t& fb, wf::geometry_t rectangle,
         bool ink, wf::pointf_t p, wf::color_t decor_color, wf::color_t effect_color,
         int title_height, int border_size, int shadow_radius);

--- a/src/smoke-shaders.hpp
+++ b/src/smoke-shaders.hpp
@@ -1,0 +1,424 @@
+static const char *motion_source = R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
+layout (binding = 2, r32f) uniform readonly image2D in_b0v;
+layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 3) uniform int px;
+layout(location = 4) uniform int py;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+layout(location = 7) uniform int rand1;
+layout(location = 8) uniform int rand2;
+layout(location = 9) uniform int radius;
+
+void motion(int x, int y)
+{
+	int i, i0, i1, j, j0, j1, d = 2;
+
+	if (x - d < 1)
+		i0 = 1;
+	else
+		i0 = x - d;
+	if (i0 + 2 * d > width - 1)
+		i1 = width - 1;
+	else
+		i1 = i0 + 2 * d;
+
+	if (y - d < 1)
+		j0 = 1;
+	else
+		j0 = y - d;
+	if (j0 + 2 * d > height - 1)
+		j1 = height - 1;
+	else
+		j1 = j0 + 2 * d;
+
+	for (i = i0; i < i1; i++)
+	{
+		for (j = j0; j < j1; j++) {
+			if (i < radius || j < radius || i > (width - 1) - radius || j > (height - 1) - radius || (i > border_size && i < (width - 1) - border_size && j > (title_height - 1) && j < (height - 1) - border_size))
+			{
+				continue;
+			}
+			vec4 b0u = imageLoad(in_b0u, ivec2(i, j));
+			vec4 b0v = imageLoad(in_b0v, ivec2(i, j));
+			vec4 b0d = imageLoad(in_b0d, ivec2(i, j));
+			float u = b0u.x;
+			float v = b0v.x;
+			float d = b0d.x;
+			imageStore(out_b0u, ivec2(i, j), vec4(u + float(256 - (rand1 & 512)), 0.0, 0.0, 0.0));
+			imageStore(out_b0v, ivec2(i, j), vec4(v + float(256 - (rand2 & 512)), 0.0, 0.0, 0.0));
+			imageStore(out_b0d, ivec2(i, j), vec4(d + 1.0, 0.0, 0.0, 0.0));
+		}
+	}
+}
+
+void main()
+{
+    motion(px, py);
+}
+)";
+
+// Generic smoke shader beginning
+static const char *smoke_header =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
+layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
+layout (binding = 2, r32f) uniform readonly image2D in_b0v;
+layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
+layout (binding = 4, r32f) uniform readonly image2D in_b1u;
+layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
+layout (binding = 5, r32f) uniform readonly image2D in_b1v;
+layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
+layout (binding = 6, r32f) uniform readonly image2D in_b1d;
+layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
+layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 0) uniform ivec4 region;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+)";
+
+// Generic main method for a compute shader which runs for a particular region
+static const char *effect_run_for_region_main = R"(
+void main()
+{
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    if (all(lessThan(pos, region.zw)))
+    {
+        pos += region.xy;
+        run_pixel(pos.x, pos.y);
+    }
+})";
+
+static const char *diffuse1_source = R"(
+void run_pixel(int x, int y)
+{
+	int k;
+	float t, a = 0.0002;
+
+	vec4 s = imageLoad(in_b0u, ivec2(x, y));
+	vec4 d1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 d2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 d3 = imageLoad(in_b1u, ivec2(x, y - 1));
+	vec4 d4 = imageLoad(in_b1u, ivec2(x, y + 1));
+	float sx = s.x;
+	float du1 = d1.x;
+	float du2 = d2.x;
+	float du3 = d3.x;
+	float du4 = d4.x;
+	float t1 = du1 + du2 + du3 + du4;
+	s = imageLoad(in_b0v, ivec2(x, y));
+	d1 = imageLoad(in_b1v, ivec2(x - 1, y));
+	d2 = imageLoad(in_b1v, ivec2(x + 1, y));
+	d3 = imageLoad(in_b1v, ivec2(x, y - 1));
+	d4 = imageLoad(in_b1v, ivec2(x, y + 1));
+	float sy = s.x;
+	du1 = d1.x;
+	du2 = d2.x;
+	du3 = d3.x;
+	du4 = d4.x;
+	float t2 = du1 + du2 + du3 + du4;
+	imageStore(out_b1u, ivec2(x, y), vec4((sx + a * t1) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4((sy + a * t2) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
+}
+)";
+
+static const char *project1_source = R"(
+void run_pixel(int x, int y) {
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b1v, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b1v, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float v1 = s3.x;
+	float v2 = s4.x;
+	imageStore(out_b0u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
+	imageStore(out_b0v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
+}
+)";
+
+static const char *project2_source = R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0 = imageLoad(in_b0v, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b0u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+})";
+
+static const char *project3_source = R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0x = imageLoad(in_b1u, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s0y = imageLoad(in_b1v, ivec2(x, y));
+	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+	float su = s0x.x;
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float sv = s0y.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b1u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+})";
+
+static const char *advect1_source = R"(
+void run_pixel(int x, int y) /* b1.u, b1.v, b1.u, b0.u */
+{
+	int stride;
+	int i, j;
+	float fx, fy;
+	stride = width;
+
+	vec4 sx = imageLoad(in_b1u, ivec2(x, y));
+	vec4 sy = imageLoad(in_b1v, ivec2(x, y));
+	float ix = float(x) - sx.x;
+	float iy = float(y) - sy.x;
+	if (ix < 0.5)
+		ix = 0.5;
+	if (iy < 0.5)
+		iy = 0.5;
+	if (ix > float(width) - 1.5)
+		ix = float(width) - 1.5;
+	if (iy > float(height) - 1.5)
+		iy = float(height) - 1.5;
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+	vec4 s0x = imageLoad(in_b1u, ivec2(i,     j));
+	vec4 s1x = imageLoad(in_b1u, ivec2(i + 1, j));
+	vec4 s2x = imageLoad(in_b1u, ivec2(i,     j + 1));
+	vec4 s3x = imageLoad(in_b1u, ivec2(i + 1, j + 1));
+	float p1 = (s0x.x * (1.0 - fx) + s1x.x * fx) * (1.0 - fy) + (s2x.x * (1.0 - fx) + s3x.x * fx) * fy;
+	imageStore(out_b0u, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+	ix = float(x) - sx.x;
+	iy = float(y) - sy.x;
+	if (ix < 0.5)
+		ix = 0.5;
+	if (iy < 0.5)
+		iy = 0.5;
+	if (ix > float(width) - 1.5)
+		ix = float(width) - 1.5;
+	if (iy > float(height) - 1.5)
+		iy = float(height) - 1.5;
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+	vec4 s0y = imageLoad(in_b1v, ivec2(i,     j));
+	vec4 s1y = imageLoad(in_b1v, ivec2(i + 1, j));
+	vec4 s2y = imageLoad(in_b1v, ivec2(i,     j + 1));
+	vec4 s3y = imageLoad(in_b1v, ivec2(i + 1, j + 1));
+	float p2 = (s0y.x * (1.0 - fx) + s1y.x * fx) * (1.0 - fy) + (s2y.x * (1.0 - fx) + s3y.x * fx) * fy;
+	imageStore(out_b0v, ivec2(x, y), vec4(p2, 0.0, 0.0, 0.0));
+})";
+
+static const char *project4_source = R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b0v, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0v, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float v1 = s3.x;
+	float v2 = s4.x;
+	imageStore(out_b1u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
+})";
+
+static const char *project5_source = R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0 = imageLoad(in_b1v, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b1u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b1u, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b1u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+})";
+
+static const char *project6_source = R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0x = imageLoad(in_b0u, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 s0y = imageLoad(in_b0v, ivec2(x, y));
+	vec4 s3 = imageLoad(in_b1u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b1u, ivec2(x, y + 1));
+	float su = s0x.x;
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float sv = s0y.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b0u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+	imageStore(out_b0v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+})";
+
+static const char *diffuse2_source = R"(
+void run_pixel(int x, int y)
+{
+	int k, stride;
+	float t, a = 0.0002;
+	stride = width;
+
+	vec4 s = imageLoad(in_b0d, ivec2(x, y));
+	vec4 d1 = imageLoad(in_b1d, ivec2(x - 1, y));
+	vec4 d2 = imageLoad(in_b1d, ivec2(x + 1, y));
+	vec4 d3 = imageLoad(in_b1d, ivec2(x, y - 1));
+	vec4 d4 = imageLoad(in_b1d, ivec2(x, y + 1));
+	float sz = s.x;
+	float du1 = d1.x;
+	float du2 = d2.x;
+	float du3 = d3.x;
+	float du4 = d4.x;
+	t = du1 + du2 + du3 + du4;
+	imageStore(out_b1d, ivec2(x, y), vec4((sz + a * t) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
+})";
+
+static const char *advect2_source = R"(
+void run_pixel(int x, int y) /*b0u, b0v, b1d, b0d*/
+{
+	int stride;
+	int i, j;
+	float fx, fy;
+	stride = width;
+
+	vec4 sx = imageLoad(in_b0u, ivec2(x, y));
+	vec4 sy = imageLoad(in_b0v, ivec2(x, y));
+	float ix = float(x) - sx.x;
+	float iy = float(y) - sy.x;
+	if (ix < 0.5)
+		ix = 0.5;
+	if (iy < 0.5)
+		iy = 0.5;
+	if (ix > float(width) - 1.5)
+		ix = float(width) - 1.5;
+	if (iy > float(height) - 1.5)
+		iy = float(height) - 1.5;
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+	vec4 s0z = imageLoad(in_b1d, ivec2(i,     j));
+	vec4 s1z = imageLoad(in_b1d, ivec2(i + 1, j));
+	vec4 s2z = imageLoad(in_b1d, ivec2(i,     j + 1));
+	vec4 s3z = imageLoad(in_b1d, ivec2(i + 1, j + 1));
+	float p1 = (s0z.x * (1.0 - fx) + s1z.x * fx) * (1.0 - fy) + (s2z.x * (1.0 - fx) + s3z.x * fx) * fy;
+	imageStore(out_b0d, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+})";
+
+static const char *render_source = R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 0) uniform ivec4 region;
+layout(location = 4) uniform bool ink;
+layout(location = 8) uniform vec4 smoke_color;
+layout(location = 9) uniform vec4 decor_color;
+
+void run_pixel(int x, int y)
+{
+	float c, r, g, b, a;
+
+	vec4 s = imageLoad(in_b0d, ivec2(x, y));
+	c = s.x * 800.0;
+	if (c > 255.0)
+		c = 255.0;
+	a = c;
+	vec3 color;
+	if (ink)
+	{
+		if (c > 2.0)
+			color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
+		else
+			color = mix(decor_color.rgb, vec3(0.0, 0.0, 0.0), clamp(a, 0.0, 1.0));
+		if (c > 1.5)
+			imageStore(out_tex, ivec2(x, y), vec4(color, 1.0));
+		else
+			imageStore(out_tex, ivec2(x, y), decor_color);
+		return;
+	} else
+	{
+		color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
+	}
+	imageStore(out_tex, ivec2(x, y), vec4(color, decor_color.a));
+})";


### PR DESCRIPTION
These changes significantly reduce the GPU usage of smoke on my computer. The idea is rather simple: instead of scheduling compute for the whole window and then filtering out the border region only, directly schedule computes for each rectangle of the border.

The second commit improves the situation a little bit more by scheduling all rectangles in parallel.