### PR TITLE
Add a single-pass-fragment-shader path

### DIFF
--- a/src/deco-effects.cpp
+++ b/src/deco-effects.cpp
@@ -2652,8 +2652,11 @@ void smoke_t::run_fragment_shader(const wf::render_target_t& fb,
     fragment_effect_only_program.uniform1f("height", rectangle.height);
     fragment_effect_only_program.uniform2f("topLeftCorner", rectangle.x, rectangle.y);
 
-    fragment_effect_only_program.uniform1i("shadow_radius", last_shadow_radius * 2);
-    fragment_effect_only_program.uniform1i("corner_radius", rounded_corner_radius);
+    if (std::string(overlay_engine) == "rounded_corners")
+    {
+        fragment_effect_only_program.uniform1i("shadow_radius", last_shadow_radius * 2);
+        fragment_effect_only_program.uniform1i("corner_radius", rounded_corner_radius);
+    }
 
     glm::vec4 color {
         shadow_color.value().r, shadow_color.value().g, shadow_color.value().b, shadow_color.value().a};

--- a/src/deco-effects.cpp
+++ b/src/deco-effects.cpp
@@ -2158,6 +2158,7 @@ void smoke_t::create_programs()
 
     static std::map<std::string, std::string> fragment_effect_sources = {
         {"clouds", effect_clouds_fragment},
+        {"neon_pattern", effect_neon_pattern_fragment},
     };
 
     static std::map<std::string, std::string> overlay_effect_sources = {

--- a/src/deco-effects.hpp
+++ b/src/deco-effects.hpp
@@ -2,7 +2,6 @@
 #include <wayfire/option-wrapper.hpp>
 #include <wayfire/core.hpp>
 #include <wayfire/opengl.hpp>
-#include <map>
 #include <GLES3/gl32.h>
 
 namespace wf
@@ -19,6 +18,7 @@ class smoke_t
         advect1_program, advect2_program, render_program, render_overlay_program,
         texture, b0u, b0v, b0d, b1u, b1v, b1d, neural_network_tex;
 
+    OpenGL::program_t fragment_effect_only_program{};
     int saved_width = -1, saved_height = -1;
 
     wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
@@ -26,6 +26,7 @@ class smoke_t
     wf::option_wrapper_t<bool> effect_animate{"pixdecor/animate"};
     wf::option_wrapper_t<int> rounded_corner_radius{"pixdecor/rounded_corner_radius"};
     wf::option_wrapper_t<wf::color_t> shadow_color{"pixdecor/shadow_color"};
+    int last_shadow_radius = 0;
 
   public:
     smoke_t();
@@ -33,6 +34,9 @@ class smoke_t
 
     void run_shader(GLuint program, int width, int height, int title_height, int border_size, int radius);
     void run_shader_region(GLuint program, const wf::region_t & region, const wf::dimensions_t & size);
+    void run_fragment_shader(const wf::render_target_t& fb,
+        wf::geometry_t rectangle, const wf::region_t& scissor);
+
     void dispatch_region(const wf::region_t& region);
 
     void step_effect(const wf::render_target_t& fb, wf::geometry_t rectangle,

--- a/src/effect-shaders.hpp
+++ b/src/effect-shaders.hpp
@@ -1,0 +1,151 @@
+static const char *generic_effect_vertex_shader = R"(
+#version 320 es
+
+in highp vec2 position;
+out highp vec2 relativePosition;
+
+uniform mat4 MVP;
+uniform vec2 topLeftCorner;
+
+void main() {
+    relativePosition = position.xy - topLeftCorner;
+    gl_Position = MVP * vec4(position.xy, 0.0, 1.0);
+})";
+
+static const char *generic_effect_fragment_header = R"(
+#version 320 es
+precision highp float;
+precision highp image2D;
+
+in highp vec2 relativePosition;
+uniform float current_time;
+uniform float width;
+uniform float height;
+
+out vec4 fragColor;
+)";
+
+static const char *generic_effect_fragment_main = R"(
+void main()
+{
+    fragColor = overlay_function(relativePosition);
+})";
+
+// ported from https://www.shadertoy.com/view/WdXBW4
+static const char *effect_clouds_fragment = R"(
+float cloudscale=2.1;  // Added cloudscale parameter
+const mat2 m = mat2(1.6, 1.2, -1.2, 1.6);
+
+vec2 hash(vec2 p) {
+    p = vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)));
+    return -1.0 + 2.0 * fract(sin(p) * 43758.5453123);
+}
+
+float noise(vec2 p) {
+    const float K1 = 0.366025404; // (sqrt(3)-1)/2;
+    const float K2 = 0.211324865; // (3-sqrt(3))/6;
+    vec2 i = floor(p + (p.x + p.y) * K1);
+    vec2 a = p - i + (i.x + i.y) * K2;
+    vec2 o = (a.x > a.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+    vec2 b = a - o + K2;
+    vec2 c = a - 1.0 + 2.0 * K2;
+    vec3 h = max(0.5 - vec3(dot(a, a), dot(b, b), dot(c, c)), 0.0);
+    vec3 n = h * h * h * h * vec3(dot(a, hash(i + 0.0)), dot(b, hash(i + o)), dot(c, hash(i + 1.0)));
+    return dot(n, vec3(70.0));
+}
+
+float fbm(vec2 n) {
+    float total = 0.0, amplitude = 0.1;
+    for (int i = 0; i < 7; i++) {
+        total += noise(n) * amplitude;
+        n = m * n;
+        amplitude *= 0.4;
+    }
+    return total;
+}
+
+vec4 effect_color(vec2 pos)
+{
+    vec2 uv = pos / vec2(width, height);
+
+    float time = 0.003 * current_time;  // Time variable for animation
+
+    float cloudPattern1 = fbm(uv * 10.0 * cloudscale + time);
+    float cloudPattern2 = fbm(uv * 5.0 * cloudscale + time);
+    float cloudPattern3 = fbm(uv * 3.0 * cloudscale + time);
+
+    // Combine different cloud patterns with different weights
+    float cloudPattern = 0.5 * cloudPattern1 + 0.3 * cloudPattern2 + 0.2 * cloudPattern3;
+
+    // Ridge noise shape
+    float ridgeNoiseShape = 0.0;
+    uv *= cloudscale * 1.1;  // Adjust scale
+    float weight = 0.8;
+    for (int i = 0; i < 8; i++) {
+        ridgeNoiseShape += abs(weight * noise(uv));
+        uv = m * uv + time;
+        weight *= 0.7;
+    }
+
+    // Noise shape
+    float noiseShape = 0.0;
+    uv = vec2(pos) / vec2(width, height);
+    uv *= cloudscale * 1.1;  // Adjust scale
+    weight = 0.7;
+    for (int i = 0; i < 8; i++) {
+        noiseShape += weight * noise(uv);
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    noiseShape *= ridgeNoiseShape + noiseShape;
+
+    // Noise color
+    float noiseColor = 0.0;
+    uv = vec2(pos) / vec2(width, height);
+    uv *= 2.0 * cloudscale;  // Adjust scale
+    weight = 0.4;
+    for (int i = 0; i < 7; i++) {
+        noiseColor += weight * noise(uv);
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    // Noise ridge color
+    float noiseRidgeColor = 0.0;
+    uv = vec2(pos) / vec2(width, height);
+    uv *= 3.0 * cloudscale;  // Adjust scale
+    weight = 0.4;
+    for (int i = 0; i < 7; i++) {
+        noiseRidgeColor += abs(weight * noise(uv));
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    noiseColor += noiseRidgeColor;
+
+    // Sky tint
+    float skytint = 0.5;
+    vec3 skyColour1 = vec3(0.1, 0.2, 0.3);
+    vec3 skyColour2 = vec3(0.4, 0.7, 1.0);
+    vec3 skycolour = mix(skyColour1, skyColour2, smoothstep(0.4, 0.6, uv.y));
+
+    // Cloud darkness
+    float clouddark = 0.5;
+
+    // Cloud Cover, Cloud Alpha
+    float cloudCover = 0.01;
+    float cloudAlpha = 2.0;
+
+    // Movement effect
+    uv = uv + time;
+
+    // Use a bright color for clouds
+    vec3 cloudColor = vec3(1.0, 1.0, 1.0); ;  // Bright white color for clouds
+
+    // Mix the cloud color with the background, considering darkness, cover, and alpha
+    vec3 finalColor = mix(skycolour, cloudColor * clouddark, cloudPattern + noiseShape + noiseColor) * (1.0 - cloudCover) + cloudColor * cloudCover;
+    finalColor = mix(skycolour, finalColor, cloudAlpha);
+
+    return vec4(finalColor, 1.0);
+})";

--- a/src/effect-shaders.hpp
+++ b/src/effect-shaders.hpp
@@ -149,3 +149,33 @@ vec4 effect_color(vec2 pos)
 
     return vec4(finalColor, 1.0);
 })";
+
+// ported from https://www.shadertoy.com/view/mtyGWy
+static const char *effect_neon_pattern_fragment = R"(
+vec3 palette(float t) {
+    vec3 a = vec3(0.5, 0.5, 0.5);
+    vec3 b = vec3(0.5, 0.5, 0.5);
+    vec3 c = vec3(1.0, 1.0, 1.0);
+    vec3 d = vec3(0.263, 0.416, 0.557);
+    return a + b * cos(6.28318 * (c * t + d));
+}
+
+vec4 effect_color(vec2 pos) {
+    vec2 uv = pos / vec2(width, height);
+    vec2 uv0 = uv;
+    vec3 finalColor = vec3(0.0);
+
+    for (float i = 0.0; i < 4.0; i++) {
+        uv = fract(uv * 1.5) - 0.5;
+        float d = length(uv) * exp(-length(uv0));
+
+        vec3 col = palette(length(uv0) + i * 0.4 + current_time * 0.000001);
+
+        d = sin(d * 8.0 + current_time * 0.02) / 8.0;
+        d = abs(d);
+        d = pow(0.01 / d, 1.2);
+        finalColor += col * d;
+    }
+
+    return vec4(finalColor, 1.0);
+})";

--- a/src/overlay-shaders.hpp
+++ b/src/overlay-shaders.hpp
@@ -1,0 +1,44 @@
+static const char *overlay_no_overlay = R"(
+vec4 overlay_function(vec2 position)
+{
+    return effect_color(position);
+})";
+
+static const char *overlay_rounded_corners = R"(
+uniform int corner_radius;
+uniform int shadow_radius;
+uniform vec4 shadow_color;
+
+vec4 overlay_function(vec2 pos)
+{
+    vec4 c = shadow_color;
+    vec4 m = vec4(0.0);
+    float diffuse = 1.0 / max(float(shadow_radius / 2), 1.0);
+
+    float distanceToEdgeX = ceil(min(pos.x, width - pos.x));
+    float distanceToEdgeY = ceil(min(pos.y, height - pos.y));
+
+    float radii_sum = float(shadow_radius) + float(corner_radius);
+
+    // We have a corner
+    if ((distanceToEdgeX <= radii_sum) && (distanceToEdgeY <= radii_sum))
+    {
+        float d = distance(vec2(distanceToEdgeX, distanceToEdgeY), vec2(radii_sum)) - float(corner_radius);
+        vec4 s = mix(c, m, 1.0 - exp(-pow(d * diffuse, 2.0)));
+
+        vec4 eff_color = effect_color(pos);
+        return mix(eff_color, s, clamp(d, 0.0, 1.0));
+    }
+
+    bool closeToX = ceil(distanceToEdgeX) < float(shadow_radius);
+    bool closeToY = ceil(distanceToEdgeY) < float(shadow_radius);
+
+    if (!closeToX && !closeToY)
+    {
+        return effect_color(pos);
+    }
+
+    // Edges
+    float d = float(shadow_radius) - (closeToX ? distanceToEdgeX : distanceToEdgeY);
+    return mix(c, m, 1.0 - exp(-pow(d * diffuse, 2.0)));
+})";


### PR DESCRIPTION
This PR aims to make it possible to optimize most of the effects which can be rendered with a single fragment shader pass. The old pipeline uses 3 passes:

- Compute pass for the effect
- Compute pass for the overlay engine
- Fragment shader pass for rendering

The new render code combines all three together in a single fragment shader pass, allowing us to also make efficient use of GL scissor. By reducing the passes, we also reduce the CPU usage.

The idea of how the shaders work:

- All of them share the same headers and the same uniforms, width, height, current_time
- Each effect needs to provide a function, `vec4 effect_color(vec2 pos)` which gives the color from the effect.
- Each overlay engine provides a function, `vec4 overlay_effect(vec2 pos)`. It may call effect_color() to get the color of the effect, or set a color on its own. For example the `none` overlay effect simply returns `effect_color(pos)`.
- The main function is the same for all combinations, it just calls `overlay_effect(pos)`.

The headers, effect, overlay and main function code are simply concatenated together to form a single shader which is then executed.