### PR TITLE
Fragment shaderz

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Scott Moreau
+Copyright (c) 2024 Ilia Bozhinov
+Copyright (c) 2024 Andrew Pliatsikas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/metadata/compile.txt
+++ b/metadata/compile.txt
@@ -1,1 +1,0 @@
-rm -rf build; PKG_CONFIG_PATH=/opt/wayfire/lib/x86_64-linux-gnu/pkgconfig:/opt/wayfire/share/pkgconfig meson setup build --prefix=/opt/wayfire && ninja -C build && sudo ninja -C build install`

--- a/metadata/compile.txt
+++ b/metadata/compile.txt
@@ -1,0 +1,1 @@
+rm -rf build; PKG_CONFIG_PATH=/opt/wayfire/lib/x86_64-linux-gnu/pkgconfig:/opt/wayfire/share/pkgconfig meson setup build --prefix=/opt/wayfire && ninja -C build && sudo ninja -C build install`

--- a/metadata/pixdecor.xml
+++ b/metadata/pixdecor.xml
@@ -56,6 +56,50 @@
 				<value>ink</value>
 				<_name>Ink</_name>
 			</desc>
+			<desc>
+				<value>clouds</value>
+				<_name>Clouds</_name>
+			</desc>
+			<desc>
+				<value>halftone</value>
+				<_name>Halftone</_name>
+			</desc>
+			<desc>
+				<value>pattern</value>
+				<_name>Pattern</_name>
+			</desc>
+			<desc>
+				<value>lava</value>
+				<_name>Lava</_name>
+			</desc>
+			<desc>
+				<value>hex</value>
+				<_name>Hex</_name>
+			</desc>
+			<desc>
+				<value>zebra</value>
+				<_name>Zebra</_name>
+			</desc>
+			<desc>
+				<value>neural_network</value>
+				<_name>Neural network</_name>
+			</desc>
+			<desc>
+				<value>hexagon_maze</value>
+				<_name>Hexagon maze</_name>
+			</desc>
+			<desc>
+				<value>raymarched_truchet</value>
+				<_name>Raymarched truchet</_name>
+			</desc>
+			<desc>
+				<value>neon_pattern</value>
+				<_name>Neon pattern</_name>
+			</desc>
+			<desc>
+				<value>neon_rings</value>
+				<_name>Neon rings</_name>
+			</desc>
 		</option>
 		<option name="effect_color" type="color">
 			<_short>Effect Color</_short>

--- a/metadata/pixdecor.xml
+++ b/metadata/pixdecor.xml
@@ -10,6 +10,21 @@
 			<default>5</default>
 			<min>0</min>
 		</option>
+		<option name="titlebar" type="bool">
+			<_short>Titlebar</_short>
+			<_long>Whether or not to render titlebar with title text and buttons.</_long>
+			<default>true</default>
+		</option>
+		<option name="maximized_borders" type="bool">
+			<_short>Draw borders on maximized windows</_short>
+			<_long>Whether or not to render side and bottom decorations on maximized windows.</_long>
+			<default>false</default>
+		</option>
+		<option name="maximized_shadows" type="bool">
+			<_short>Draw shadows on maximized windows</_short>
+			<_long>Whether or not to allocate space for shadows on maximized windows.</_long>
+			<default>false</default>
+		</option>
 		<option name="ignore_views" type="string">
 			<_short>Decoration disabled for specified window types</_short>
 			<_long>Disables window decoration for windows matching the specified criteria.</_long>
@@ -40,6 +55,23 @@
 			<_long>Color of the window titlebar text when it does not have focus.</_long>
 			<default>0.7 0.7 0.7 1.0</default>
 		</option>
+		<option name="overlay_engine" type="string">
+			<_short>Overlay Engine</_short>
+			<_long>Sets the overlay engine.</_long>
+			<default>none</default>
+			<desc>
+				<value>none</value>
+				<_name>None</_name>
+			</desc>
+			<desc>
+				<value>rounded_corners</value>
+				<_name>Rounded Corners</_name>
+			</desc>
+			<desc>
+				<value>beveled_glass</value>
+				<_name>Beveled Glass</_name>
+			</desc>
+		</option>
 		<option name="effect_type" type="string">
 			<_short>Effect Type</_short>
 			<_long>Sets the effect type.</_long>
@@ -56,6 +88,15 @@
 				<value>ink</value>
 				<_name>Ink</_name>
 			</desc>
+			<desc>
+				<value>fumes</value>
+				<_name>Fumes</_name>
+			</desc>
+			<desc>
+				<value>fast_smoke</value>
+				<_name>Fast Smoke</_name>
+			</desc>
+			
 			<desc>
 				<value>clouds</value>
 				<_name>Clouds</_name>
@@ -104,18 +145,65 @@
 				<value>deco</value>
 				<_name>Deco</_name>
 			</desc>
+			<desc>
+				<value>ice</value>
+				<_name>Ice</_name>
+			</desc>
+			<desc>
+				<value>fire</value>
+				<_name>Fire</_name>
+			</desc>
+			<desc>
+				<value>flame</value>
+				<_name>Flame</_name>
+			</desc>
+		</option>
+			<option name="compute_fragment_shader" type="string">
+			<_short>Shader Type</_short>
+			<_long>Sets the shader type.</_long>
+			<default>fragment_shader</default>
+			<desc>
+				<value>fragment_shader</value>
+				<_name>Fragment Shader</_name>
+			</desc>
+			<desc>
+				<value>compute_shader</value>
+				<_name>Compute Shader</_name>
+			</desc>
 		</option>
 		<option name="effect_color" type="color">
 			<_short>Effect Color</_short>
 			<_long>Color of the titlebar background effect.</_long>
 			<default>0.88 0.11 0.14 1.0</default>
 		</option>
-		<option name="effect_diffuse_iterations" type="int">
-			<_short>Effect Diffuse</_short>
-			<_long>How many iterations to use for diffusing the effect. Less iterations mean less shader dispatch invocations.</_long>
+		<option name="animate" type="bool">
+			<_short>Animate Effects</_short>
+			<_long>WARNING: Enabling this option can use lots of system resources. Enables animating and constant repainting of window decorations.</_long>
+			<default>false</default>
+		</option>
+		<option name="rounded_corner_radius" type="int">
+			<_short>Rounded Corner Radius</_short>
+			<_long>The radius for corners.</_long>
 			<default>5</default>
-			<min>1</min>
-			<max>5</max>
+			<min>0</min>
+		</option>
+		<option name="shadow_radius" type="int">
+			<_short>Shadow Radius</_short>
+			<_long>The radius for shadows.</_long>
+			<default>10</default>
+			<min>0</min>
+		</option>
+		<option name="shadow_color" type="color">
+			<_short>Shadow Color</_short>
+			<_long>Color of the drop shadows.</_long>
+			<default>0.0 0.0 0.0 0.25</default>
+		</option>
+			<option name="beveled_radius" type="int">
+			<_short>Beveled Radius</_short>
+			<_long>The radius of beveled effect.</_long>
+			<default>4</default>
+			<min>0</min>
+			<max>10</max>
 		</option>
 	</plugin>
 </wayfire>

--- a/metadata/pixdecor.xml
+++ b/metadata/pixdecor.xml
@@ -100,6 +100,10 @@
 				<value>neon_rings</value>
 				<_name>Neon rings</_name>
 			</desc>
+			<desc>
+				<value>deco</value>
+				<_name>Deco</_name>
+			</desc>
 		</option>
 		<option name="effect_color" type="color">
 			<_short>Effect Color</_short>

--- a/src/deco-button.cpp
+++ b/src/deco-button.cpp
@@ -10,7 +10,7 @@
 
 namespace wf
 {
-namespace decor
+namespace pixdecor
 {
 button_t::button_t(const decoration_theme_t& t, std::function<void()> damage) :
     theme(t), damage_callback(damage)
@@ -64,14 +64,17 @@ void button_t::set_pressed(bool is_pressed)
     add_idle_damage();
 }
 
-void button_t::render(const wf::render_target_t& fb, wf::geometry_t geometry,
-    wf::geometry_t scissor)
+void button_t::render(const wf::render_target_t& fb, wf::geometry_t geometry, const wf::region_t& scissor)
 {
-    OpenGL::render_begin(fb);
-    fb.logic_scissor(scissor);
     OpenGL::render_texture(button_texture.tex, fb, geometry, {1, 1, 1, this->hover},
-        OpenGL::TEXTURE_TRANSFORM_INVERT_Y);
-    OpenGL::render_end();
+        OpenGL::TEXTURE_TRANSFORM_INVERT_Y | OpenGL::RENDER_FLAG_CACHED);
+    for (auto& box : scissor)
+    {
+        fb.logic_scissor(wlr_box_from_pixman_box(box));
+        OpenGL::draw_cached();
+    }
+
+    OpenGL::clear_cached();
 
     if (this->hover.running())
     {
@@ -102,7 +105,6 @@ void button_t::add_idle_damage()
     this->idle_damage.run_once([=] ()
     {
         this->damage_callback();
-        update_texture();
     });
 }
 }

--- a/src/deco-button.hpp
+++ b/src/deco-button.hpp
@@ -13,7 +13,7 @@
 
 namespace wf
 {
-namespace decor
+namespace pixdecor
 {
 class decoration_theme_t;
 
@@ -66,7 +66,7 @@ class button_t
      * @param scissor The scissor rectangle to render.
      */
     void render(const wf::render_target_t& fb, wf::geometry_t geometry,
-        wf::geometry_t scissor);
+        const wf::region_t& scissor);
 
   private:
     const decoration_theme_t& theme;

--- a/src/deco-effects.cpp
+++ b/src/deco-effects.cpp
@@ -2,10 +2,15 @@
 
 #include "deco-effects.hpp"
 
+#include <wayfire/option-wrapper.hpp>
+
+
 namespace wf
 {
 namespace decor
 {
+
+
 static const char *motion_source =
     R"(
 #version 320 es
@@ -815,6 +820,1403 @@ void main()
 }
 )";
 
+
+static const char *render_source_clouds =
+    R"(
+
+#version 320 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+layout(location = 9) uniform float current_time;
+float cloudscale=2.1;  // Added cloudscale parameter
+
+const mat2 m = mat2(1.6, 1.2, -1.2, 1.6);
+
+vec2 hash(vec2 p) {
+    p = vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)));
+    return -1.0 + 2.0 * fract(sin(p) * 43758.5453123);
+}
+
+float noise(vec2 p) {
+    const float K1 = 0.366025404; // (sqrt(3)-1)/2;
+    const float K2 = 0.211324865; // (3-sqrt(3))/6;
+    vec2 i = floor(p + (p.x + p.y) * K1);
+    vec2 a = p - i + (i.x + i.y) * K2;
+    vec2 o = (a.x > a.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+    vec2 b = a - o + K2;
+    vec2 c = a - 1.0 + 2.0 * K2;
+    vec3 h = max(0.5 - vec3(dot(a, a), dot(b, b), dot(c, c)), 0.0);
+    vec3 n = h * h * h * h * vec3(dot(a, hash(i + 0.0)), dot(b, hash(i + o)), dot(c, hash(i + 1.0)));
+    return dot(n, vec3(70.0));
+}
+
+float fbm(vec2 n) {
+    float total = 0.0, amplitude = 0.1;
+    for (int i = 0; i < 7; i++) {
+        total += noise(n) * amplitude;
+        n = m * n;
+        amplitude *= 0.4;
+    }
+    return total;
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    vec2 uv = vec2(pos) / vec2(gl_NumWorkGroups.x * gl_WorkGroupSize.x, gl_NumWorkGroups.y * gl_WorkGroupSize.y);
+
+    float time = 0.003 * current_time;  // Time variable for animation
+
+    float cloudPattern1 = fbm(uv * 10.0 * cloudscale + time);
+    float cloudPattern2 = fbm(uv * 5.0 * cloudscale + time);
+    float cloudPattern3 = fbm(uv * 3.0 * cloudscale + time);
+
+    // Combine different cloud patterns with different weights
+    float cloudPattern = 0.5 * cloudPattern1 + 0.3 * cloudPattern2 + 0.2 * cloudPattern3;
+
+    // Ridge noise shape
+    float ridgeNoiseShape = 0.0;
+    uv *= cloudscale * 1.1;  // Adjust scale
+    float weight = 0.8;
+    for (int i = 0; i < 8; i++) {
+        ridgeNoiseShape += abs(weight * noise(uv));
+        uv = m * uv + time;
+        weight *= 0.7;
+    }
+
+    // Noise shape
+    float noiseShape = 0.0;
+    uv = vec2(pos) / vec2(gl_NumWorkGroups.x * gl_WorkGroupSize.x, gl_NumWorkGroups.y * gl_WorkGroupSize.y);
+    uv *= cloudscale * 1.1;  // Adjust scale
+    weight = 0.7;
+    for (int i = 0; i < 8; i++) {
+        noiseShape += weight * noise(uv);
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    noiseShape *= ridgeNoiseShape + noiseShape;
+
+    // Noise color
+    float noiseColor = 0.0;
+    uv = vec2(pos) / vec2(gl_NumWorkGroups.x * gl_WorkGroupSize.x, gl_NumWorkGroups.y * gl_WorkGroupSize.y);
+    uv *= 2.0 * cloudscale;  // Adjust scale
+    weight = 0.4;
+    for (int i = 0; i < 7; i++) {
+        noiseColor += weight * noise(uv);
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    // Noise ridge color
+    float noiseRidgeColor = 0.0;
+    uv = vec2(pos) / vec2(gl_NumWorkGroups.x * gl_WorkGroupSize.x, gl_NumWorkGroups.y * gl_WorkGroupSize.y);
+    uv *= 3.0 * cloudscale;  // Adjust scale
+    weight = 0.4;
+    for (int i = 0; i < 7; i++) {
+        noiseRidgeColor += abs(weight * noise(uv));
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    noiseColor += noiseRidgeColor;
+
+    // Sky tint
+    float skytint = 0.5;
+    vec3 skyColour1 = vec3(0.1, 0.2, 0.3);
+    vec3 skyColour2 = vec3(0.4, 0.7, 1.0);
+    vec3 skycolour = mix(skyColour1, skyColour2, smoothstep(0.4, 0.6, uv.y));
+
+    // Cloud darkness
+    float clouddark = 0.5;
+
+    // Cloud Cover, Cloud Alpha
+    float cloudCover = 0.01;
+    float cloudAlpha = 2.0;
+
+    // Movement effect
+    uv = uv + time;
+
+    // Use a bright color for clouds
+    vec3 cloudColor = vec3(1.0, 1.0, 1.0); ;  // Bright white color for clouds
+
+    // Mix the cloud color with the background, considering darkness, cover, and alpha
+    vec3 finalColor = mix(skycolour, cloudColor * clouddark, cloudPattern + noiseShape + noiseColor) * (1.0 - cloudCover) + cloudColor * cloudCover;
+    finalColor = mix(skycolour, finalColor, cloudAlpha);
+
+    imageStore(out_tex, pos, vec4(finalColor, 1.0));
+}
+
+
+)";
+
+
+
+
+
+
+
+
+static const char *render_source_halftone =
+    R"(
+#version 310 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 9) uniform float  time;
+
+const vec2 resolution = vec2(1280.0, 720.0);
+const float timeFactor = 0.025;
+
+float rand(vec2 uv) {
+    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec2 rotate(vec2 p, float theta) {
+    vec2 sncs = vec2(sin(theta), cos(theta));
+    return vec2(p.x * sncs.y - p.y * sncs.x, p.x * sncs.x + p.y * sncs.y);
+}
+
+float swirl(vec2 coord, float t) {
+    float l = length(coord) / resolution.x;
+    float phi = atan(coord.y, coord.x + 1e-6);
+    return sin(l * 10.0 + phi - t * 4.0) * 0.5 + 0.5;
+}
+
+float halftone(vec2 coord, float angle, float t, float amp) {
+    coord -= resolution * 0.5;
+    float size = resolution.x / (60.0 + sin(time * timeFactor * 0.5) * 50.0);
+    vec2 uv = rotate(coord / size, angle / 180.0 * 3.14);
+    vec2 ip = floor(uv); // column, row
+    vec2 odd = vec2(0.5 * mod(ip.y, 2.0), 0.0); // odd line offset
+    vec2 cp = floor(uv - odd) + odd; // dot center
+    float d = length(uv - cp - 0.5) * size; // distance
+    float r = swirl(cp * size, t) * size * 0.5 * amp; // dot radius
+    return 1.0 - clamp(d  - r, 0.0, 1.0);
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    vec3 c1 = 1.0 - vec3(1.0, 0.0, 0.0) * halftone(vec2(pos),   0.0, time * timeFactor * 1.00, 0.7);
+    vec3 c2 = 1.0 - vec3(0.0, 1.0, 0.0) * halftone(vec2(pos),  30.0, time * timeFactor * 1.33, 0.7);
+    vec3 c3 = 1.0 - vec3(0.0, 0.0, 1.0) * halftone(vec2(pos), -30.0, time * timeFactor * 1.66, 0.7);
+    vec3 c4 = 1.0 - vec3(1.0, 1.0, 1.0) * halftone(vec2(pos),  60.0, time * timeFactor * 2.13, 0.4);
+
+    // Output the final color
+    imageStore(out_tex, pos, vec4(c1 * c2 * c3 * c4, 1.0));
+}
+
+)";
+
+static const char *render_source_lava =
+    R"(
+#version 320 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) uniform readonly image2D in_tex;
+layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 9) uniform float current_time;
+
+vec3 effect(float speed, vec2 uv, float time, float scale) {
+    float t = mod(time * 0.005, 6.0);
+    float rt = 0.00000000000001 * sin(t * 0.45);
+
+    mat2 m1 = mat2(cos(rt), -sin(rt), -sin(rt), cos(rt));
+    vec2 uva = uv * m1 * scale;
+    float irt = 0.005 * cos(t * 0.05);
+    mat2 m2 = mat2(sin(irt), cos(irt), -cos(irt), sin(irt));
+
+    for (int i = 1; i < 40; i += 1) {
+        float it = float(i);
+        uva *= m2;
+        uva.y += -1.0 + (0.6 / it) * cos(t + it * uva.x + 0.5 * it) * float(mod(it, 0.5) == 0.0);
+        uva.x += 1.0 + (0.5 / it) * cos(t + it * uva.y * 0.1 / 5.0 + 0.5 * (it + 15.0));  // Adjust the scaling factor for y-coordinate
+    }
+
+    float n = 0.5;
+    float r = n + n * sin(4.0 * uva.x + t);
+    float gb = n + n * sin(3.0 * uva.y);
+    return vec3(r, gb * 0.8 * r, gb * r);
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+
+    vec2 uv = vec2(pos) / vec2(1000, 2000);
+    uv = 2.0 * uv - 1.0;
+    uv *= (10.3 + 0.1 * sin(current_time * 0.01));
+   // uv.y -= current_time * 0.013;
+//uv.x -= current_time * 0.026;
+    vec3 col = effect(0.001, uv, current_time, 0.5);
+    // col += effect(0.5, uv * 3.0, 2.0 * current_time + 10.0, 0.5) * 0.3;
+    // col += effect(0.5, sin(current_time * 0.01) * uv * 2.0, 2.0 * current_time + 10.0, 0.5) * 0.1;
+
+    // Output the final color to the output texture
+    imageStore(out_tex, pos, vec4(col, 1.0));
+}
+)";
+
+static const char *render_source_pattern =
+    R"(
+#version 310 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;
+layout(local_size_x = 30, local_size_y = 30, local_size_z = 1) in;
+
+layout(location = 9) uniform float time;
+const vec2 resolution = vec2(1280.0, 720.0);  // Adjusted to 720p
+
+float rand(vec2 uv)
+{
+    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 hue2rgb(float h)
+{
+    h = fract(h) * 6.0 - 2.0;
+    return clamp(vec3(abs(h - 1.0) - 1.0, 2.0 - abs(h), 2.0 - abs(h - 2.0)), 0.0, 1.0);
+}
+
+vec3 eyes(vec2 coord)
+{
+    const float pi = 3.141592;
+    float t = 0.4 * time * 0.05; 
+    float aspectRatio = resolution.x / resolution.y;
+    float div = 20.0;
+    float sc = resolution.y / div ;
+
+    vec2 p = (coord - resolution / 2.0) / sc - 0.5;
+
+    // center offset
+    float dir = floor(rand(floor(p) + floor(t) * 0.11) * 4.0) * pi / 2.0;
+    vec2 offs = vec2(sin(dir), cos(dir)) * 0.6;
+    offs *= smoothstep(0.0, 0.1, fract(t));
+    offs *= smoothstep(0.4, 0.5, 1.0 - fract(t));
+
+    // circles
+    float l = length(fract(p) + offs - 0.5);
+    float rep = sin((rand(floor(p)) * 2.0 + 2.0) * t) * 4.0 + 5.0;
+    float c = (abs(0.5 - fract(l * rep + 0.5)) - 0.25) * sc / rep;
+
+    // grid lines
+    vec2 gr = (abs(0.5 - fract(p + 0.5)) - 0.05) * sc;
+    c = clamp(min(min(c, gr.x), gr.y), 0.0, 1.0);
+
+    return hue2rgb(rand(floor(p) * 0.3231)) * c;
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    vec3 color = eyes(vec2(pos));
+
+    // Output the final color
+    imageStore(out_tex, pos, vec4(color, 1.0));
+}
+
+
+)";
+
+
+static const char *render_source_hex =
+    R"(
+#version 320 es
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+layout(binding = 0, rgba32f) writeonly uniform highp image2D OutputImage;
+
+layout(location = 9) uniform float iTime;
+uniform vec2 iResolution;
+
+float rand(vec2 co) {
+    return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+// Hexagon function
+vec4 hexagon(vec2 p)
+{
+    vec2 q = vec2(p.x * 2.0 * 0.5773503, p.y + p.x * 0.5773503);
+
+    vec2 pi = floor(q);
+    vec2 pf = fract(q);
+
+    float v = mod(pi.x * 9.0, 0.0);
+
+    float ca = step(1.0, v);
+    float cb = step(2.0, v);
+    vec2 ma = step(pf.xy, pf.yx);
+
+    float e = 0.0;
+    float f = length((fract(p) - 10.5) * vec2(1.0, 0.85));
+
+    return vec4(pi + ca - cb * ma, e, f);
+}
+
+void main() {
+    ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    vec2 uv = (vec2(globalID) + 0.5) / 1920.0; // Assuming iResolution is 1920x1080
+
+    // Generate a random value
+    float randVal = rand(uv);
+
+    // Apply hexagon logic
+    vec2 pos = (-1920.0 + 2.0 * vec2(globalID)) / 1080.0;
+    vec4 h = hexagon(60.0 * pos + vec2(0.5 * iTime * 0.125));
+    
+ float col = 0.01 + 0.15 * rand(vec2(h.xy)) * 1.0;
+    col *= 4.3 + 0.15 * sin(10.0 * h.z);
+    // Use hardcoded colors for shades
+// Use hardcoded colors for shades with gradient
+vec3 shadeColor1 = vec3(0.1, 0.1, 0.1) + 1.1 * col * h.z;   // Dark gray with gradient
+vec3 shadeColor2 = vec3(0.4, 0.4, 0.4) + 1.1 * col;  // Gray with gradient
+vec3 shadeColor3 = vec3(0.9, 0.9, 0.9) + .1 * col;  // Light gray with gradient
+
+
+   
+
+    // Use different hardcoded colors based on the random value
+    vec3 finalColor = mix(shadeColor1, mix(shadeColor2, shadeColor3, randVal), col);
+
+    // Use imageStore instead of writing to buffer
+    imageStore(OutputImage, globalID, vec4(finalColor, 1.0));
+}
+
+
+
+)";
+
+
+static const char *render_source_zebra =
+    R"(
+#version 310 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 9) uniform float time;
+const float resolutionY = 720.0; // Set to constant resolution of 720p
+const float pi = 3.14159265359;
+const float timeFactor = 0.05; // Adjust this factor to control the speed of the animation
+
+float rand(vec2 uv)
+{
+    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    float size = resolutionY / 10.0; // cell size in pixel
+
+    vec2 p1 = vec2(pos) / size; // normalized pos
+    vec2 p2 = fract(p1) - 0.5; // relative pos from cell center
+
+    // random number
+    float rnd = dot(floor(p1), vec2(12.9898, 78.233));
+    rnd = fract(sin(rnd) * 43758.5453);
+
+    // rotation matrix
+    float phi = rnd * pi * 2.0 + time * 0.4 * timeFactor;
+    mat2 rot = mat2(cos(phi), -sin(phi), sin(phi), cos(phi));
+
+    vec2 p3 = rot * p2; // apply rotation
+    p3.y += sin(p3.x * 5.0 + time * 2.0 * timeFactor) * 0.12; // wave
+
+    float rep = fract(rnd * 13.285) * 8.0 + 2.0; // line repetition
+    float gr = fract(p3.y * rep + time * 0.8 * timeFactor); // repeating gradient
+
+    // make antialiased line by saturating the gradient
+    float c = clamp((0.25 - abs(0.5 - gr)) * size * 0.75 / rep, 0.0, 1.0);
+    c *= max(0.0, 1.0 - length(p2) * 0.6); // darken corners
+
+    vec2 bd = (0.5 - abs(p2)) * size - 2.0; // border lines
+    c *= clamp(min(bd.x, bd.y), 0.0, 1.0);
+
+    // Output the final color
+    imageStore(out_tex, pos, vec4(c, c, c, 1.0));
+}
+
+)";
+
+
+
+static const char *render_source_neural_network =
+    R"(
+
+#version 320 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 9) uniform float time; // Animated time
+
+uniform vec2 iResolution;
+uniform float iTime;
+
+mat2 rotate2D(float r) {
+    float c = cos(r);
+    float s = sin(r);
+    return mat2(c, -s, s, c);
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+
+    // Normalized pixel coordinates (from 0 to 1)
+    vec2 uv = (vec2(pos) - 0.5 * float(gl_NumWorkGroups.x)) / float(gl_WorkGroupSize.x);
+    
+    // Scale the uv coordinates by a factor of 8
+    uv *= 0.05;
+
+    vec3 col = vec3(0);
+    float t = 0.05 * time;
+
+    vec2 n = vec2(0), q;
+    vec2 N = vec2(0);
+    vec2 p = uv + sin(t * 0.1) / 10.0;
+    float S = 10.0;
+    mat2 m = rotate2D(1.0);
+
+    for (float j = 0.0; j < 30.0; j++) {
+        p *= m;
+        n *= m;
+        q = p * S + j + n + t;
+        n += sin(q);
+        N += cos(q) / S;
+        S *= 1.2;
+    }
+
+    col = vec3(1, 2, 4) * pow((N.x + N.y + 0.2) + 0.005 / length(N), 2.1);
+
+    imageStore(out_tex, pos, vec4(col, 1.0));
+}
+)";
+
+
+
+static const char *render_source_hexagon_maze =
+    R"(
+#version 320 es
+
+precision highp float;
+precision highp int;
+precision highp image2D;
+
+//layout (location = 0) out vec4 fragColor;
+layout (binding = 0, rgba32f) writeonly uniform image2D fragColor;
+
+
+layout(location = 9) uniform float iTime;
+uniform vec2 iResolution;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+
+// Interlaced variation - Interesting, but patched together in a hurry.
+//#define INTERLACING
+
+// A quick hack to get rid of the winding overlay - in order to show the maze only.
+//#define MAZE_ONLY
+
+
+
+// Helper vector. If you're doing anything that involves regular triangles or hexagons, the
+// 30-60-90 triangle will be involved in some way, which has sides of 1, sqrt(3) and 2.
+const vec2 s = vec2(1, 1.7320508);
+
+// Standard vec2 to float hash - Based on IQ's original.
+float hash21(vec2 p){ return fract(sin(dot(p, vec2(141.173, 289.927)))*43758.5453); }
+
+
+// Standard 2D rotation formula.
+mat2 r2(in float a){ float c = cos(a), s = sin(a); return mat2(c, -s, s, c); }
+
+
+// The 2D hexagonal isosuface function: If you were to render a horizontal line and one that
+// slopes at 60 degrees, mirror, then combine them, you'd arrive at the following.
+float hex(in vec2 p){
+    
+    p = abs(p);
+    
+    // Below is equivalent to:
+    //return max(p.x*.5 + p.y*.866025, p.x); 
+
+    return max(dot(p, s*.5), p.x); // Hexagon.
+    
+}
+
+// This function returns the hexagonal grid coordinate for the grid cell, and the corresponding 
+// hexagon cell ID - in the form of the central hexagonal point. That's basically all you need to 
+// produce a hexagonal grid.
+//
+// When working with 2D, I guess it's not that important to streamline this particular function.
+// However, if you need to raymarch a hexagonal grid, the number of operations tend to matter.
+// This one has minimal setup, one "floor" call, a couple of "dot" calls, a ternary operator, etc.
+// To use it to raymarch, you'd have to double up on everything - in order to deal with 
+// overlapping fields from neighboring cells, so the fewer operations the better.
+vec4 getHex(vec2 p){
+    
+    // The hexagon centers: Two sets of repeat hexagons are required to fill in the space, and
+    // the two sets are stored in a "vec4" in order to group some calculations together. The hexagon
+    // center we'll eventually use will depend upon which is closest to the current point. Since 
+    // the central hexagon point is unique, it doubles as the unique hexagon ID.
+    vec4 hC = floor(vec4(p, p - vec2(.5, 1))/s.xyxy) + .5;
+    
+    // Centering the coordinates with the hexagon centers above.
+    vec4 h = vec4(p - hC.xy*s, p - (hC.zw + .5)*s);
+    
+    // Nearest hexagon center (with respect to p) to the current point. In other words, when
+    // "h.xy" is zero, we're at the center. We're also returning the corresponding hexagon ID -
+    // in the form of the hexagonal central point. Note that a random constant has been added to 
+    // "hC.zw" to further distinguish it from "hC.xy."
+    //
+    // On a side note, I sometimes compare hex distances, but I noticed that Iomateron compared
+    // the Euclidian version, which seems neater, so I've adopted that.
+    return dot(h.xy, h.xy)<dot(h.zw, h.zw) ? vec4(h.xy, hC.xy) : vec4(h.zw, hC.zw + vec2(.5, 1));
+    
+}
+
+// Dot pattern.
+float dots(in vec2 p){
+    
+    p = abs(fract(p) - .5);
+    
+    return length(p); // Circles.
+    
+    //return (p.x + p.y)/1.5 + .035; // Diamonds.
+    
+    //return max(p.x, p.y) + .03; // Squares.
+    
+    //return max(p.x*.866025 + p.y*.5, p.y) + .01; // Hexagons.
+    
+    //return min((p.x + p.y)*.7071, max(p.x, p.y)) + .08; // Stars.
+    
+    
+}
+
+
+// Distance field for the arcs. I think it's called poloidal rotation, or something like that.
+float dfPol(vec2 p){
+     
+    return length(p); // Circular arc.
+    
+    // There's no rule that says the arcs have to be rounded. Here's a hexagonal one.
+    //return hex(p);
+    
+    // Dodecahedron.
+    //return max(hex(p), hex(r2(3.14159/6.)*p));
+    
+    // Triangle.
+    //return max(abs(p.x)*.866025 - p.y, p.y);
+    
+}
+
+
+// Truchet pattern distance field.
+float df(vec2 p, float dir){
+     
+    // Weird UV coordinates. The first entry is the Truchet distance field itself,
+    // and the second is the polar angle of the arc pixel. The extra ".1" is just a bit
+    // of mutational scaling, or something... I can't actually remember why it's there. :)
+    vec2 uv = vec2(p.x + .1, p.y);//*vec2(1, 1); // Scaling.
+    
+    // A checkered dot pattern. At present the pattern needs to have flip symmetry about
+    // the center, but I'm pretty sure regular textures could be applied with a few
+    // minor changes. Due to the triangular nature of the Truchet pattern, factors of "3"
+    // were necessary, but factors of "1.5" seemed to work too. Hence the "4.5."
+    return min(dots(uv*4.5), dots(uv*4.5 + .5)) - .3;
+    
+}
+
+
+// Polar coordinate of the arc pixel.
+float getPolarCoord(vec2 q, float dir){
+    
+    // The actual animation. You perform that before polar conversion.
+    q = r2((iTime*0.05)*dir)*q;
+    
+    // Polar angle.
+    const float aNum = 1.;
+    float a = atan(q.y, q.x);
+   
+    // Wrapping the polar angle.
+    return mod(a/3.14159, 2./aNum) - 1./aNum;
+   
+    
+}
+
+
+
+void main() {
+	vec2 iResolution = vec2(1280.0, 720.0);
+    ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+    vec2 fragCoord = vec2(id);
+    float res = clamp(iResolution.y, 300.0, 600.0);
+    vec2 u = (fragCoord - iResolution.xy*.5)/res;
+    vec2 sc = u*4. + s.yx*(iTime*0.05)/12.;
+    vec4 h = getHex(sc);
+    vec4 h2 = getHex(sc - 1.0 / s);
+    vec4 h3 = getHex(sc + 1.0 / s);
+    vec2 p = h.xy;
+    float eDist = hex(p);
+    float cDist = dot(p, p);
+    float rnd = hash21(h.zw);
+ //float aRnd = sin(rnd*6.283 + (iTime*0.05)*1.5)*.5 + .5; // Animating the random number.
+    
+    #ifdef INTERLACING
+    // Random vec3 - used for some overlapping.
+    //vec3 lRnd = vec3(rnd*14.4 + .81, fract(rnd*21.3 + .97), fract(rnd*7.2 + .63));
+    vec3 lRnd = vec3(hash21(h.zw + .23), hash21(h.zw + .96), hash21(h.zw + .47));
+    #endif
+    
+    // It's possible to control the randomness to form some kind of repeat pattern.
+    //rnd = mod(h.z + h.w, 2.);
+    
+
+    // Redundant here, but I might need it later.
+    float dir = 1.;
+    
+
+    
+    // Storage vector.
+    vec2 q;
+    
+    
+    // If the grid cell's random ID is above a threshold, flip the Y-coordinates.
+    if(rnd>.5) p.y = -p.y;
+        
+    
+
+    // Determining the closest of the three arcs to the current point, the keeping a copy
+    // of the vector used to produce it. That way, you'll know just to render that particular
+    // decorated arc, lines, etc - instead of all three. 
+    const float r = 1.;
+    const float th = .2; // Arc thickness.
+    
+    // Arc one.
+    q = p - vec2(0, r)/s;
+    vec3 da = vec3(q, dfPol(q));
+    
+    // Arc two. "r2" could be hardcoded, but this is a relatively cheap 2D example.
+    q = r2(3.14159*2./3.)*p - vec2(0, r)/s;
+    vec3 db = vec3(q, dfPol(q));
+
+     // Arc three. 
+    q = r2(3.14159*4./3.)*p - vec2(0, r)/s;
+    vec3 dc = vec3(q, dfPol(q));
+    
+    // Compare distance fields, and return the vector used to produce the closest one.
+    vec3 q3 = da.z<db.z && da.z<dc.z? da : db.z<dc.z ? db : dc;
+    
+    
+    // TRUCHET PATTERN
+    //
+    // Set the poloidal arc radius: You can change the poloidal distance field in 
+    // the "dfPol" function to a different curve shape, but you'll need to change
+    // the radius to one of the figures below.
+    //
+    q3.z -= .57735/2. + th/2.;  // Circular and dodecahedral arc/curves.
+    //q3.z -= .5/2. + th/2.;  // Hexagon curve.
+    //q3.z -= .7071/2. + th/2.;  // Triangle curve.
+    
+    q3.z = max(q3.z, -th - q3.z); // Chop out the smaller radius. The result is an arc.
+    
+    // Store the result in "d" - only to save writing "q3.z" everywhere.
+    float d = q3.z;
+    
+    // If you'd like to see the maze by itself.
+    #ifdef MAZE_ONLY
+    d += 1e5;
+    #endif
+    
+    // Truchet border.
+    float dBord = max(d - .015, -d);
+    
+
+    
+ 
+    
+    // MAZE BORDERS
+    // Producing the stright-line arc borders. Basically, we're rendering some hexagonal borders around
+    // the arcs. The result is the hexagonal maze surrounding the Truchet pattern.
+    q = q3.xy;
+    const float lnTh = .05;
+    q = abs(q);
+    
+    float arcBord = hex(q);
+    //float arcBord = length(q); // Change arc length to ".57735."
+    //float arcBord = max(hex(q), hex(r2(3.14159/6.)*q)); // Change arc length to ".57735."
+    
+    // Making the hexagonal arc.
+    float lnOuter = max(arcBord - .5, -(arcBord - .5 + lnTh)); //.57735
+    
+    
+    #ifdef INTERLACING
+    float ln = min(lnOuter, (q.y*.866025 + q.x*.5, q.x) - lnTh);
+    #else
+    float ln = min(lnOuter, arcBord - lnTh);
+    #endif
+    float lnBord = ln - .03; // Border lines to the maze border, if that makes any sense. :)
+     
+       
+    ///////
+    // The moving Truchet pattern. The polar coordinates consist of a wrapped angular coordinate,
+    // and the distance field itself.
+    float a = getPolarCoord(q3.xy, dir);
+    float d2 = df(vec2(q3.z, a), dir);
+    float dMask = smoothstep(0., .015, d);
+    vec3 bg =  mix(vec3(0, .0, .6), vec3(0, .9, .0), dot(sin(u*6. - cos(u*3.)), vec2(.4/2.)) + .4); 
+    
+    
+    
+    bg = mix(bg, bg.xzy, dot(sin(u*6. - cos(u*3.)), vec2(.4/2.)) + .4);
+    bg = mix(bg, bg.zxy, dot(sin(u*3. + cos(u*3.)), vec2(.1/2.)) + .1);
+   
+    #ifdef INTERLACING
+    // Putting in background cube lines for the interlaced version.
+    float hLines = smoothstep(0., .02, eDist - .5 + .02);
+    bg = mix(bg, vec3(0), smoothstep(0., .02, ln)*dMask*hLines);
+    #endif
+    
+    // Lines over the maze lines. Applying difference logic, depending on whether the 
+    // pattern is interlaced or not.
+    const float tr = 1.;
+
+    float eDist2 = hex(h2.xy);
+    float hLines2 = smoothstep(0., .02, eDist2 - .5 + .02);
+    #ifdef INTERLACING
+    if(rnd>.5 && lRnd.x<.5) hLines2 *= smoothstep(0., .02, ln);
+    if(lRnd.x>.5) hLines2 *= dMask;
+    #else
+    if(rnd>.5) hLines2 *= smoothstep(0., .02, ln);
+    hLines2 *= dMask;
+    #endif
+    bg = mix(bg, vec3(0), hLines2*tr);
+    
+    float eDist3 = hex(h3.xy);
+    float hLines3 = smoothstep(0., .02, eDist3 - .5 + .02);
+    #ifdef INTERLACING
+    if(rnd<=.5 && lRnd.x>.5) hLines3 *= smoothstep(0., .02, ln);
+    if(lRnd.x>.5) hLines3 *= dMask;
+    #else
+    if(rnd<=.5) hLines3 *= smoothstep(0., .02, ln);
+    hLines3 *= dMask;
+    #endif
+    bg = mix(bg, vec3(0), hLines3*tr);
+
+
+    // Using the two off-centered hex coordinates to give the background a bit of highlighting.
+    float shade = max(1.25 - dot(h2.xy, h2.xy)*2., 0.);
+    shade = min(shade, max(dot(h3.xy, h3.xy)*3. + .25, 0.));
+    bg = mix(bg, vec3(0), (1.-shade)*.5); 
+    
+    // I wanted to change the colors of everything at the last minute. It's pretty hacky, so
+    // when I'm feeling less lazy, I'll tidy it up. :)
+    vec3 dotCol = bg.zyx*vec3(1.5, .4, .4);
+    vec3 bCol = mix(bg.zyx, bg.yyy, .25);
+    bg = mix(bg.yyy, bg.zyx, .25);
+    
+    
+
+    // Under the random threshold, and we draw the lines under the Truchet pattern.
+    #ifdef INTERLACING
+    if(lRnd.x>.5){
+       bg = mix(bg, vec3(0), (1. - smoothstep(0., .015, lnBord)));
+       bg = mix(bg, bCol, (1. - smoothstep(0., .015, ln))); 
+       // Center lines.
+       bg = mix(bg, vec3(0), smoothstep(0., .02, eDist3 - .5 + .02)*tr);
+    }
+    #else
+    bg = mix(bg, vec3(0), (1. - smoothstep(0., .015, lnBord)));
+    bg = mix(bg, bCol, (1. - smoothstep(0., .015, ln)));
+    #endif
+
+
+   
+     // Apply the Truchet shadow to the background.
+    bg = mix(bg, vec3(0), (1. - smoothstep(0., .07, d))*.5);
+    
+    
+    // Place the Truchet field to the background, with some additional shading to give it a 
+    // slightly rounded, raised feel.
+    //vec3 col = mix(bg, vec3(1)*max(-d*3. + .7, 0.), (1. - dMask)*.65);
+    // Huttarl suggest slightly more shading on the snake-like pattern edges, so I added just a touch.
+    vec3 col = mix(bg, vec3(1)*max(-d*9. + .4, 0.), (1. - dMask)*.65);
+
+
+
+    
+    // Apply the moving dot pattern to the Truchet.
+    //dotCol = mix(dotCol, dotCol.xzy, dot(sin(u*3.14159*2. - cos(u.yx*3.14159*2.)*3.14159), vec2(.25)) + .5);
+    col = mix(col, vec3(0), (1. - dMask)*(1. - smoothstep(0., .02, d2)));
+    col = mix(col, dotCol, (1. - dMask)*(1. - smoothstep(0., .02, d2 + .125)));
+    
+    // Truchet border.
+    col = mix(col, vec3(0), 1. - smoothstep(0., .015, dBord));
+    
+    #ifdef INTERLACING
+    // Over the random threshold, and we draw the lines over the Truchet.
+    if(lRnd.x<=.5){
+        col = mix(col, vec3(0), (1. - smoothstep(0., .015, lnBord)));
+        col = mix(col, bCol, (1. - smoothstep(0., .015, ln)));  
+        // Center lines.
+        col = mix(col, vec3(0), smoothstep(0., .02, eDist2 - .5 + .02)*tr);
+    }
+    #endif
+
+
+        
+    
+    // Subtle vignette.
+    u = fragCoord/iResolution.xy;
+    col *= pow(16.*u.x*u.y*(1. - u.x)*(1. - u.y) , .125) + .25;
+    // Colored variation.
+    //col = mix(pow(min(vec3(1.5, 1, 1)*col, 1.), vec3(1, 3, 16)), col, 
+            //pow(16.*u.x*u.y*(1. - u.x)*(1. - u.y) , .25)*.75 + .25);    
+    
+    
+
+ 
+
+ 
+    
+    // Using the edge distance to produce some repeat contour lines. Standard stuff.
+    //if (rnd>.5) h.xy = -h.yx;
+    //float cont = clamp(cos(hex(h.xy)*6.283*12.)*1.5 + 1.25, 0., 1.);
+    //col = mix(col, vec3(0), (1. - smoothstep(0., .015, ln))*(smoothstep(0., .015, d))*(1.-cont)*.5);
+    
+    
+ 
+    // Very basic hatch line effect.
+    float gr = dot(col, vec3(.299, .587, .114));
+    float hatch = (gr<.45)? clamp(sin((sc.x - sc.y)*3.14159*40.)*2. + 1.5, 0., 1.) : 1.;
+    float hatch2 = (gr<.25)? clamp(sin((sc.x + sc.y)*3.14159*40.)*2. + 1.5, 0., 1.) : 1.;
+
+    col *= min(hatch, hatch2)*.5 + .5;    
+    col *= clamp(sin((sc.x - sc.y)*3.14159*80.)*1.5 + .75, 0., 1.)*.25 + 1.;  
+    
+ 
+ 
+    vec2 u2 = fragCoord / iResolution.xy;
+    col *= pow(16.0 * u2.x * u2.y * (1.0 - u2.x) * (1.0 - u2.y), 0.125) + 0.25;
+
+    imageStore(fragColor, id, vec4(sqrt(max(col, 0.0)), 1.0));
+}
+
+
+
+)";
+
+
+static const char *render_source_raymarched_truchet  =
+    R"(
+#version 320 es
+
+precision highp float;
+precision highp int;
+precision highp image2D;
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+layout(binding = 0, rgba8) writeonly uniform image2D imageOut;
+
+
+layout(location = 9) uniform float  iTime;
+uniform vec2 iResolution;
+
+float heightMap(in vec2 p) { 
+    
+    p *= 5.;
+    
+    // Hexagonal coordinates.
+    vec2 h = vec2(p.x + p.y*.57735, p.y*1.1547);
+    
+    // Closest hexagon center.
+    vec2 f = fract(h); h -= f;
+    float c = fract((h.x + h.y)/3.);
+    h =  c<.666 ?   c<.333 ?  h  :  h + 1.  :  h  + step(f.yx, f); 
+
+    p -= vec2(h.x - h.y*.5, h.y*.8660254);
+    
+    // Rotate (flip, in this case) random hexagons. Otherwise, you'd have a bunch of circles only.
+    // Note that "h" is unique to each hexagon, so we can use it as the random ID.
+    c = fract(cos(dot(h, vec2(41, 289)))*43758.5453); // Reusing "c."
+    p -= p*step(c, .5)*2.; // Equivalent to: if (c<.5) p *= -1.;
+    
+    // Minimum squared distance to neighbors. Taking the square root after comparing, for speed.
+    // Three partitions need to be checked due to the flipping process.
+    p -= vec2(-1, 0);
+    c = dot(p, p); // Reusing "c" again.
+    p -= vec2(1.5, .8660254);
+    c = min(c, dot(p, p));
+    p -= vec2(0, -1.73205);
+    c = min(c, dot(p, p));
+    
+    return sqrt(c);
+    
+    // Wrapping the values - or folding the values over (abs(c-.5)*2., cos(c*6.283*1.), etc) - to produce 
+    // the nicely lined-up, wavy patterns. I"m perfoming this step in the "map" function. It has to do 
+    // with coloring and so forth.
+    //c = sqrt(c);
+    //c = cos(c*6.283*1.) + cos(c*6.283*2.);
+    //return (clamp(c*.6+.5, 0., 1.));
+
+}
+
+// Raymarching an XY-plane - raised a little by the hexagonal Truchet heightmap. Pretty standard.
+float map(vec3 p){
+    
+    
+    float c = heightMap(p.xy); // Height map.
+    // Wrapping, or folding the height map values over, to produce the nicely lined-up, wavy patterns.
+    c = cos(c*6.283*1.) + cos(c*6.283*2.);
+    c = (clamp(c*.6+.5, 0., 1.));
+
+    
+    // Back plane, placed at vec3(0., 0., 1.), with plane normal vec3(0., 0., -1).
+    // Adding some height to the plane from the heightmap. Not much else to it.
+    return 1. - p.z - c*.025;
+
+    
+}
+
+// The normal function with some edge detection and curvature rolled into it. Sometimes, it's possible to 
+// get away with six taps, but we need a bit of epsilon value variance here, so there's an extra six.
+vec3 getNormal(vec3 p, inout float edge, inout float crv) { 
+    
+    vec2 e = vec2(.01, 0); // Larger epsilon for greater sample spread, thus thicker edges.
+
+    // Take some distance function measurements from either side of the hit point on all three axes.
+    float d1 = map(p + e.xyy), d2 = map(p - e.xyy);
+    float d3 = map(p + e.yxy), d4 = map(p - e.yxy);
+    float d5 = map(p + e.yyx), d6 = map(p - e.yyx);
+    float d = map(p)*2.;    // The hit point itself - Doubled to cut down on calculations. See below.
+     
+    // Edges - Take a geometry measurement from either side of the hit point. Average them, then see how
+    // much the value differs from the hit point itself. Do this for X, Y and Z directions. Here, the sum
+    // is used for the overall difference, but there are other ways. Note that it's mainly sharp surface 
+    // curves that register a discernible difference.
+    edge = abs(d1 + d2 - d) + abs(d3 + d4 - d) + abs(d5 + d6 - d);
+    //edge = max(max(abs(d1 + d2 - d), abs(d3 + d4 - d)), abs(d5 + d6 - d)); // Etc.
+    
+    // Once you have an edge value, it needs to normalized, and smoothed if possible. How you 
+    // do that is up to you. This is what I came up with for now, but I might tweak it later.
+    edge = smoothstep(0., 1., sqrt(edge/e.x*2.));
+    
+    // We may as well use the six measurements to obtain a rough curvature value while we're at it.
+    crv = clamp((d1 + d2 + d3 + d4 + d5 + d6 - d*3.)*32. + .6, 0., 1.);
+    
+    // Redoing the calculations for the normal with a more precise epsilon value.
+    e = vec2(.0025, 0);
+    d1 = map(p + e.xyy), d2 = map(p - e.xyy);
+    d3 = map(p + e.yxy), d4 = map(p - e.yxy);
+    d5 = map(p + e.yyx), d6 = map(p - e.yyx); 
+    
+    
+    // Return the normal.
+    // Standard, normalized gradient mearsurement.
+    return normalize(vec3(d1 - d2, d3 - d4, d5 - d6));
+}
+
+
+
+// I keep a collection of occlusion routines... OK, that sounded really nerdy. :)
+// Anyway, I like this one. I'm assuming it's based on IQ's original.
+float calculateAO(in vec3 p, in vec3 n)
+{
+    float sca = 2., occ = 0.;
+    for(float i=0.; i<5.; i++){
+    
+        float hr = .01 + i*.5/4.;        
+        float dd = map(n * hr + p);
+        occ += (hr - dd)*sca;
+        sca *= 0.7;
+    }
+    return clamp(1.0 - occ, 0., 1.);    
+}
+
+
+/*
+// Surface bump function. Cheap, but with decent visual impact.
+float bumpSurf3D( in vec3 p){
+    
+    float c = heightMap((p.xy + p.z*.025)*6.);
+    c = cos(c*6.283*3.);
+    //c = sqrt(clamp(c+.5, 0., 1.));
+    c = (c*.5 + .5);
+    
+    return c;
+
+}
+
+// Standard function-based bump mapping function.
+vec3 dbF(in vec3 p, in vec3 nor, float bumpfactor){
+    
+    const vec2 e = vec2(0.001, 0);
+    float ref = bumpSurf3D(p);                 
+    vec3 grad = (vec3(bumpSurf3D(p - e.xyy),
+                      bumpSurf3D(p - e.yxy),
+                      bumpSurf3D(p - e.yyx) )-ref)/e.x;                     
+          
+    grad -= nor*dot(nor, grad);          
+                      
+    return normalize( nor + grad*bumpfactor );
+    
+}
+*/
+
+// Compact, self-contained version of IQ's 3D value noise function.
+float n3D(vec3 p){
+    
+    const vec3 s = vec3(7, 157, 113);
+    vec3 ip = floor(p); p -= ip; 
+    vec4 h = vec4(0., s.yz, s.y + s.z) + dot(ip, s);
+    p = p*p*(3. - 2.*p); //p *= p*p*(p*(p * 6. - 15.) + 10.);
+    h = mix(fract(sin(h)*43758.5453), fract(sin(h + s.x)*43758.5453), p.x);
+    h.xy = mix(h.xz, h.yw, p.y);
+    return mix(h.x, h.y, p.z); // Range: [0, 1].
+}
+
+// Simple environment mapping. Pass the reflected vector in and create some
+// colored noise with it. The normal is redundant here, but it can be used
+// to pass into a 3D texture mapping function to produce some interesting
+// environmental reflections.
+vec3 envMap(vec3 rd, vec3 sn){
+    
+    vec3 sRd = rd; // Save rd, just for some mixing at the end.
+    
+    // Add a time component, scale, then pass into the noise function.
+    rd.xy -= iTime*.25 *0.0125;
+    rd *= 3.;
+    
+    float c = n3D(rd)*.57 + n3D(rd*2.)*.28 + n3D(rd*4.)*.15; // Noise value.
+    c = smoothstep(0.4, 1., c); // Darken and add contast for more of a spotlight look.
+    
+    vec3 col = vec3(c, c*c, c*c*c*c); // Simple, warm coloring.
+    //vec3 col = vec3(min(c*1.5, 1.), pow(c, 2.5), pow(c, 12.)); // More color.
+    
+    // Mix in some more red to tone it down and return.
+    return mix(col, col.yzx, sRd*.25+.25); 
+    
+}
+
+
+
+// vec2 to vec2 hash.
+vec2 hash22(vec2 p) { 
+
+    // Faster, but doesn't disperse things quite as nicely as other combinations. :)
+    float n = sin(dot(p, vec2(41, 289)));
+    return fract(vec2(262144, 32768)*n)*.75 + .25; 
+    
+    // Animated.
+    //p = fract(vec2(262144, 32768)*n); 
+    //return sin( p*6.2831853 + iTime *0.0125)*.35 + .65; 
+    
+}
+
+// 2D 2nd-order Voronoi: Obviously, this is just a rehash of IQ's original. I've tidied
+// up those if-statements. Since there's less writing, it should go faster. That's how 
+// it works, right? :)
+//
+float Voronoi(in vec2 p){
+    
+    vec2 g = floor(p), o; p -= g;
+    
+    vec3 d = vec3(1); // 1.4, etc. "d.z" holds the distance comparison value.
+    
+    for(int y = -1; y <= 1; y++){
+        for(int x = -1; x <= 1; x++){
+            
+            o = vec2(x, y);
+            o += hash22(g + o) - p;
+            
+            d.z = dot(o, o); 
+            // More distance metrics.
+            //o = abs(o);
+            //d.z = max(o.x*.8666 + o.y*.5, o.y);// 
+            //d.z = max(o.x, o.y);
+            //d.z = (o.x*.7 + o.y*.7);
+            
+            d.y = max(d.x, min(d.y, d.z));
+            d.x = min(d.x, d.z); 
+                       
+        }
+    }
+    
+    return max(d.y/1.2 - d.x*1., 0.)/1.2;
+    //return d.y - d.x; // return 1.-d.x; // etc.
+    
+}
+
+
+
+void main() {
+
+	vec2 iResolution = vec2(1920.0, 1080.0);
+    ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+
+
+
+    // Unit directional ray - Coyote's observation.
+    vec3 rd = normalize(vec3(2. * vec2(id) - iResolution.xy, iResolution.y));
+
+
+    float tm = (iTime / 2.) * 0.0125;
+
+    // Rotate the XY-plane back and forth. Note that sine and cosine are kind of rolled into one.
+    vec2 a = sin(vec2(1.570796, 0) + sin(tm / 4.) * .3);
+
+    // Fabrice's observation.
+    rd.xy = mat2(a, -a.y, a.x) * rd.xy;
+
+    // Ray origin. Moving in the X-direction to the right.
+  //  vec3 ro = vec3(tm, cos(tm / 4.), 0.);
+vec3 ro = vec3(0.0,0.0, 0.);
+    // Light position, hovering around behind the camera.
+    vec3 lp = ro + vec3(cos(tm / 2.) * .5, sin(tm / 2.) * .5, -.5);
+
+    // Standard raymarching segment. Because of the straightforward setup, not many iterations are necessary.
+    float d, t = 0.;
+    for (int j = 0; j < 32; j++) {
+        d = map(ro + rd * t); // distance to the function.
+        t += d * .7;          // Total distance from the camera to the surface.
+
+        // The plane "is" the far plane, so no far=plane break is needed.
+        if (d < 0.001)
+            break;
+    }
+
+    // Edge and curve value. Passed into, and set, during the normal calculation.
+    float edge, crv;
+
+    // Surface position, surface normal and light direction.
+    vec3 sp = ro + rd * t;
+    vec3 sn = getNormal(sp, edge, crv);
+    vec3 ld = lp - sp;
+
+    
+    // Coloring and texturing the surface.
+    //
+    // Height map.
+    float c = heightMap(sp.xy); 
+    
+    // Folding, or wrapping, the values above to produce the snake-like pattern that lines up with the randomly
+    // flipped hex cells produced by the height map.
+    vec3 fold = cos(vec3(1, 2, 4)*c*6.283);
+    
+    // Using the height map value, then wrapping it, to produce a finer grain Truchet pattern for the overlay.
+    float c2 = heightMap((sp.xy + sp.z*.025)*6.);
+    c2 = cos(c2*6.283*3.);
+    c2 = (clamp(c2+.5, 0., 1.)); 
+
+    
+    // Function based bump mapping. I prefer none in this example, but it's there if you want it.   
+    //if(temp.x>0. || temp.y>0.) sn = dbF(sp, sn, .001);
+    
+    // Surface color value.
+    vec3 oC = vec3(1);
+
+    if(fold.x>0.) oC = vec3(1, .05, .1)*c2; // Reddish pink with finer grained Truchet overlay.
+    
+    if(fold.x<0.05 && (fold.y)<0.) oC = vec3(1, .7, .45)*(c2*.25 + .75); // Lighter lined borders.
+    else if(fold.x<0.) oC = vec3(1, .8, .4)*c2; // Gold, with overlay.
+        
+    //oC *= n3D(sp*128.)*.35 + .65; // Extra fine grained noisy texturing.
+
+     
+    // Sending some greenish particle pulses through the snake-like patterns. With all the shininess going 
+    // on, this effect is a little on the subtle side.
+    float p1 = 1.0 - smoothstep(0., .1, fold.x*.5+.5); // Restrict to the snake-like path.
+    // Other path.
+    //float p2 = 1.0 - smoothstep(0., .1, cos(heightMap(sp.xy + 1. + (iTime*0.0125)/4.)*6.283)*.5+.5);
+    float p2 = 1.0 - smoothstep(0., .1, Voronoi(sp.xy*4. + vec2(tm, cos(tm/4.))));
+    p1 = (p2 + .25)*p1; // Overlap the paths.
+    oC += oC.yxz*p1*p1; // Gives a kind of electron effect. Works better with just Voronoi, but it'll do.
+    
+   
+    
+    
+    float lDist = max(length(ld), 0.001); // Light distance.
+    float atten = 1./(1. + lDist*.125); // Light attenuation.
+    
+    ld /= lDist; // Normalizing the light direction vector.
+    
+   
+    float diff = max(dot(ld, sn), 0.); // Diffuse.
+    float spec = pow(max( dot( reflect(-ld, sn), -rd ), 0.0 ), 16.); // Specular.
+    float fre = pow(clamp(dot(sn, rd) + 1., .0, 1.), 3.); // Fresnel, for some mild glow.
+    
+    // Shading. Note, there are no actual shadows. The camera is front on, so the following
+    // two functions are enough to give a shadowy appearance.
+    crv = crv*.9 + .1; // Curvature value, to darken the crevices.
+    float ao = calculateAO(sp, sn); // Ambient occlusion, for self shadowing.
+
+ 
+    
+    // Combining the terms above to light the texel.
+ vec3 col = oC*(diff + .5) + vec3(1., .7, .4)*spec*2. + vec3(.4, .7, 1)*fre;
+
+    
+   col += (oC*.5+.5)*envMap(reflect(rd, sn), sn)*6.; // Fake environment mapping.
+ 
+    
+    // Edges.
+    col *= 1. - edge*.85; // Darker edges.   
+    
+    // Applying the shades.
+    col *= (atten*crv*ao);
+
+col *= 2.0;
+ // Rough gamma correction, then write to the output buffer.
+    vec3 finalColor = sqrt(clamp(col, 0., 1.));
+    ivec2 fragCoord = ivec2(id);  // Convert to ivec2
+    imageStore(imageOut, fragCoord, vec4(finalColor, 1.0));  // Use vec4 instead of uvec4
+
+}
+)";
+
+
+
+static const char *render_source_neon_pattern  =
+    R"(
+
+ #version 320 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) uniform readonly image2D in_tex;
+layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+//uniform float current_time;  // Assuming this is the global time variable
+layout(location = 9) uniform float current_time; 
+
+vec3 palette(float t) {
+    vec3 a = vec3(0.5, 0.5, 0.5);
+    vec3 b = vec3(0.5, 0.5, 0.5);
+    vec3 c = vec3(1.0, 1.0, 1.0);
+    vec3 d = vec3(0.263, 0.416, 0.557);
+    return a + b * cos(6.28318 * (c * t + d));
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+
+    vec2 uv = vec2(pos) / vec2(800, 600);
+    vec2 uv0 = uv;
+    vec3 finalColor = vec3(0.0);
+
+    for (float i = 0.0; i < 4.0; i++) {
+        uv = fract(uv * 1.5) - 0.5;
+
+        float d = length(uv) * exp(-length(uv0));
+
+        vec3 col = palette(length(uv0) + i * 0.4 + current_time * 0.000001);
+
+        d = sin(d * 8.0 + current_time * 0.02) / 8.0;
+        d = abs(d);
+
+        d = pow(0.01 / d, 1.2);
+
+        finalColor += col * d;
+    }
+
+    // Output the final color to the output texture
+    imageStore(out_tex, pos, vec4(finalColor, 1.0));
+}
+)";
+
+
+
+static const char *render_source_neon_rings  =
+    R"(
+#version 320 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) uniform readonly image2D in_tex;
+layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 3) uniform int width;
+layout(location = 4) uniform int height;
+layout(location = 9) uniform float current_time; // Animated time
+
+#define PI 3.14159265358979323846
+#define TWO_PI 6.28318530717958647692
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+
+    // Number of circles
+    int numCircles = 5;
+
+    // Initialize final color
+    vec3 finalColor = vec3(0.0);
+
+    for (int i = 0; i < numCircles; ++i) {
+        // Calculate UV coordinates for each circle
+        vec2 uv = vec2(pos) / vec2(300, 300);
+
+        // Calculate polar coordinates
+        float a = atan(uv.y, uv.x);
+        float r = length(uv) * (0.2 + 0.1 * float(i));
+
+        // Map polar coordinates to UV
+        uv = vec2(a / TWO_PI, r);
+
+        // Apply horizontal movement based on time for each circle
+        float xOffset = sin(current_time * 0.02 + float(i)) * 0.2;
+        uv.x += xOffset;
+
+        // Time-dependent color
+        float xCol = (uv.x - (current_time / 300000.0)) * 3.0;
+        xCol = mod(xCol, 3.0);
+        vec3 horColour = vec3(0.25, 0.25, 0.25);
+
+        if (xCol < 1.0) {
+            horColour.r += 1.0 - xCol;
+            horColour.g += xCol;
+        } else if (xCol < 2.0) {
+            xCol -= 1.0;
+            horColour.g += 1.0 - xCol;
+            horColour.b += xCol;
+        } else {
+            xCol -= 2.0;
+            horColour.b += 1.0 - xCol;
+            horColour.r += xCol;
+        }
+
+        // Draw color beam
+        uv = (2.0 * uv) - 1.0;
+        float beamWidth = (0.7 + 0.5 * cos(uv.x * 1.0 * TWO_PI * 0.15 * clamp(floor(5.0 + 1.0 * cos(current_time)), 0.0, 1.0))) * abs(1.0 / (30.0 * uv.y));
+        vec3 horBeam = vec3(beamWidth);
+        
+        // Add the color for the current circle to the final color
+        finalColor += ((horBeam) * horColour);
+    }
+
+    // Output the final color to the output texture
+    imageStore(out_tex, pos, vec4(finalColor, 1.0));
+}
+
+
+)";
+
+
 void setup_shader(GLuint *program, std::string source)
 {
     auto compute_shader  = OpenGL::compile_shader(source.c_str(), GL_COMPUTE_SHADER);
@@ -844,6 +2246,7 @@ static void seed_random()
     clock_gettime(CLOCK_MONOTONIC, &ts);
     srandom(ts.tv_nsec);
 }
+wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
 
 smoke_t::smoke_t()
 {
@@ -859,7 +2262,55 @@ smoke_t::smoke_t()
     setup_shader(&project6_program, project6_source);
     setup_shader(&advect1_program, advect1_source);
     setup_shader(&advect2_program, advect2_source);
+
     setup_shader(&render_program, render_source);
+    
+ 	if (std::string(effect_type) == "clouds")
+ 	{
+   	setup_shader(&render_program, render_source_clouds);
+	}
+	else if (std::string(effect_type) == "halftone")
+ 	{
+   	setup_shader(&render_program, render_source_halftone);
+	}
+	else if (std::string(effect_type) == "pattern")
+ 	{
+   	setup_shader(&render_program, render_source_pattern);
+	}
+	else if (std::string(effect_type) == "lava")
+ 	{
+   	setup_shader(&render_program, render_source_lava);
+	}
+	else if (std::string(effect_type) == "hex")
+ 	{
+   	setup_shader(&render_program, render_source_hex);
+	}
+	else if (std::string(effect_type) == "zebra")
+ 	{
+   	setup_shader(&render_program, render_source_zebra);
+	}
+	else if (std::string(effect_type) == "neural_network")
+ 	{
+   	setup_shader(&render_program, render_source_neural_network);
+	}
+	else if (std::string(effect_type) == "hexagon_maze")
+ 	{
+   	setup_shader(&render_program, render_source_hexagon_maze);
+	}
+	else if (std::string(effect_type) == "raymarched_truchet")
+ 	{
+   	setup_shader(&render_program, render_source_raymarched_truchet);
+	}
+	else if (std::string(effect_type) == "neon_pattern")
+ 	{
+   	setup_shader(&render_program, render_source_neon_pattern );
+	}
+	else if (std::string(effect_type) == "neon_rings")
+ 	{
+   	setup_shader(&render_program, render_source_neon_rings );
+	}
+
+ 
     texture = b0u = b0v = b0d = b1u = b1v = b1d = GLuint(-1);
     OpenGL::render_end();
     seed_random();
@@ -878,7 +2329,9 @@ smoke_t::~smoke_t()
     GL_CALL(glDeleteProgram(project6_program));
     GL_CALL(glDeleteProgram(advect1_program));
     GL_CALL(glDeleteProgram(advect2_program));
+
     GL_CALL(glDeleteProgram(render_program));
+    
     destroy_textures();
 }
 
@@ -939,7 +2392,7 @@ void smoke_t::run_shader(GLuint program, int width, int height, int title_height
 }
 
 void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangle,
-    bool ink, wf::pointf_t p, wf::color_t decor_color, wf::color_t effect_color,
+    bool ink,  wf::pointf_t p, wf::color_t decor_color, wf::color_t effect_color,
     int title_height, int border_size, int diffuse_iterations)
 {
     if ((rectangle.width <= 0) || (rectangle.height <= 0))
@@ -1059,6 +2512,7 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
     }
 
     run_shader(advect2_program, rectangle.width, rectangle.height, title_height, border_size);
+   
     GL_CALL(glUseProgram(render_program));
     GL_CALL(glActiveTexture(GL_TEXTURE0 + 0));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
@@ -1078,6 +2532,8 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
     GL_CALL(glUniform1i(6, rectangle.height));
     GL_CALL(glUniform4fv(7, 1, effect_color_f));
     GL_CALL(glUniform4fv(8, 1, decor_color_f));
+    GL_CALL(glUniform1f(9, wf::get_current_time() / 30.0));
+
     GL_CALL(glDispatchCompute(rectangle.width / 15, rectangle.height / 15, 1));
     GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
     GL_CALL(glActiveTexture(GL_TEXTURE0 + 0));

--- a/src/deco-effects.cpp
+++ b/src/deco-effects.cpp
@@ -823,13 +823,16 @@ void main()
 
 static const char *render_source_clouds =
     R"(
-
 #version 320 es
 precision highp float;
 precision highp image2D;
 
 layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float current_time;
 float cloudscale=2.1;  // Added cloudscale parameter
 
@@ -865,6 +868,25 @@ float fbm(vec2 n) {
 
 void main() {
     ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    
+    
+
+
+//    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+    
+    
+      // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
+    
     vec2 uv = vec2(pos) / vec2(gl_NumWorkGroups.x * gl_WorkGroupSize.x, gl_NumWorkGroups.y * gl_WorkGroupSize.y);
 
     float time = 0.003 * current_time;  // Time variable for animation
@@ -950,6 +972,7 @@ void main() {
 }
 
 
+
 )";
 
 
@@ -967,6 +990,16 @@ precision highp image2D;
 
 layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+
+
+
+
+
 
 layout(location = 9) uniform float  time;
 
@@ -1001,7 +1034,23 @@ float halftone(vec2 coord, float angle, float t, float amp) {
 }
 
 void main() {
+
+
     ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+    
+    
+      // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
+    
     vec3 c1 = 1.0 - vec3(1.0, 0.0, 0.0) * halftone(vec2(pos),   0.0, time * timeFactor * 1.00, 0.7);
     vec3 c2 = 1.0 - vec3(0.0, 1.0, 0.0) * halftone(vec2(pos),  30.0, time * timeFactor * 1.33, 0.7);
     vec3 c3 = 1.0 - vec3(0.0, 0.0, 1.0) * halftone(vec2(pos), -30.0, time * timeFactor * 1.66, 0.7);
@@ -1011,7 +1060,14 @@ void main() {
     imageStore(out_tex, pos, vec4(c1 * c2 * c3 * c4, 1.0));
 }
 
+
+
+
+
+
+
 )";
+
 
 static const char *render_source_lava =
     R"(
@@ -1023,6 +1079,11 @@ layout(binding = 0, rgba32f) uniform readonly image2D in_tex;
 layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float current_time;
 
 vec3 effect(float speed, vec2 uv, float time, float scale) {
@@ -1049,10 +1110,24 @@ vec3 effect(float speed, vec2 uv, float time, float scale) {
 
 void main() {
     ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-
-    vec2 uv = vec2(pos) / vec2(1000, 2000);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+vec2 uv = vec2(pos) / vec2(1000, 2000);
     uv = 2.0 * uv - 1.0;
     uv *= (10.3 + 0.1 * sin(current_time * 0.01));
+
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
+
+    
    // uv.y -= current_time * 0.013;
 //uv.x -= current_time * 0.026;
     vec3 col = effect(0.001, uv, current_time, 0.5);
@@ -1062,7 +1137,10 @@ void main() {
     // Output the final color to the output texture
     imageStore(out_tex, pos, vec4(col, 1.0));
 }
+
+
 )";
+
 
 static const char *render_source_pattern =
     R"(
@@ -1073,6 +1151,11 @@ precision highp image2D;
 layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;
 layout(local_size_x = 30, local_size_y = 30, local_size_z = 1) in;
 
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float time;
 const vec2 resolution = vec2(1280.0, 720.0);  // Adjusted to 720p
 
@@ -1117,6 +1200,24 @@ vec3 eyes(vec2 coord)
 
 void main() {
     ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+
+ 
+ 
+ 
+  //  ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
+
     vec3 color = eyes(vec2(pos));
 
     // Output the final color
@@ -1129,13 +1230,18 @@ void main() {
 
 static const char *render_source_hex =
     R"(
-#version 320 es
+#version 310 es
 precision highp float;
 precision highp int;
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 layout(binding = 0, rgba32f) writeonly uniform highp image2D OutputImage;
 
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float iTime;
 uniform vec2 iResolution;
 
@@ -1162,9 +1268,20 @@ vec4 hexagon(vec2 p)
 
     return vec4(pi + ca - cb * ma, e, f);
 }
-
 void main() {
     ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+    // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
+
     vec2 uv = (vec2(globalID) + 0.5) / 1920.0; // Assuming iResolution is 1920x1080
 
     // Generate a random value
@@ -1174,16 +1291,13 @@ void main() {
     vec2 pos = (-1920.0 + 2.0 * vec2(globalID)) / 1080.0;
     vec4 h = hexagon(60.0 * pos + vec2(0.5 * iTime * 0.125));
     
- float col = 0.01 + 0.15 * rand(vec2(h.xy)) * 1.0;
+    float col = 0.01 + 0.15 * rand(vec2(h.xy)) * 1.0;
     col *= 4.3 + 0.15 * sin(10.0 * h.z);
-    // Use hardcoded colors for shades
-// Use hardcoded colors for shades with gradient
-vec3 shadeColor1 = vec3(0.1, 0.1, 0.1) + 1.1 * col * h.z;   // Dark gray with gradient
-vec3 shadeColor2 = vec3(0.4, 0.4, 0.4) + 1.1 * col;  // Gray with gradient
-vec3 shadeColor3 = vec3(0.9, 0.9, 0.9) + .1 * col;  // Light gray with gradient
 
-
-   
+    // Use hardcoded colors for shades with gradient
+    vec3 shadeColor1 = vec3(0.1, 0.1, 0.1) + 1.1 * col * h.z;   // Dark gray with gradient
+    vec3 shadeColor2 = vec3(0.4, 0.4, 0.4) + 1.1 * col;  // Gray with gradient
+    vec3 shadeColor3 = vec3(0.9, 0.9, 0.9) + 0.1 * col;  // Light gray with gradient
 
     // Use different hardcoded colors based on the random value
     vec3 finalColor = mix(shadeColor1, mix(shadeColor2, shadeColor3, randVal), col);
@@ -1191,6 +1305,7 @@ vec3 shadeColor3 = vec3(0.9, 0.9, 0.9) + .1 * col;  // Light gray with gradient
     // Use imageStore instead of writing to buffer
     imageStore(OutputImage, globalID, vec4(finalColor, 1.0));
 }
+
 
 
 
@@ -1206,6 +1321,10 @@ precision highp image2D;
 layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float time;
 const float resolutionY = 720.0; // Set to constant resolution of 720p
 const float pi = 3.14159265359;
@@ -1217,7 +1336,20 @@ float rand(vec2 uv)
 }
 
 void main() {
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    //ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+        ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
     float size = resolutionY / 10.0; // cell size in pixel
 
     vec2 p1 = vec2(pos) / size; // normalized pos
@@ -1248,6 +1380,7 @@ void main() {
     imageStore(out_tex, pos, vec4(c, c, c, 1.0));
 }
 
+
 )";
 
 
@@ -1255,12 +1388,23 @@ void main() {
 static const char *render_source_neural_network =
     R"(
 
-#version 320 es
+#version 310 es
 precision highp float;
 precision highp image2D;
 
-layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
+//layout(binding = 0, rgba32f) readonly uniform highp image2D neural_network_tex;  // Use binding point 0
+layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;  // Use binding point 1
+
+//layout(binding = 0, rgba32f) writeonly uniform highp image2D out_tex;
+
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+
+
 
 layout(location = 9) uniform float time; // Animated time
 
@@ -1274,7 +1418,19 @@ mat2 rotate2D(float r) {
 }
 
 void main() {
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+     ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
 
     // Normalized pixel coordinates (from 0 to 1)
     vec2 uv = (vec2(pos) - 0.5 * float(gl_NumWorkGroups.x)) / float(gl_WorkGroupSize.x);
@@ -1319,7 +1475,10 @@ precision highp image2D;
 //layout (location = 0) out vec4 fragColor;
 layout (binding = 0, rgba32f) writeonly uniform image2D fragColor;
 
-
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float iTime;
 uniform vec2 iResolution;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
@@ -1461,8 +1620,21 @@ float getPolarCoord(vec2 q, float dir){
 
 
 void main() {
-	vec2 iResolution = vec2(1280.0, 720.0);
+    vec2 iResolution = vec2(1280.0, 720.0);
     ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
     vec2 fragCoord = vec2(id);
     float res = clamp(iResolution.y, 300.0, 600.0);
     vec2 u = (fragCoord - iResolution.xy*.5)/res;
@@ -1723,7 +1895,7 @@ void main() {
 
 static const char *render_source_raymarched_truchet  =
     R"(
-#version 320 es
+#version 310 es
 
 precision highp float;
 precision highp int;
@@ -1732,7 +1904,10 @@ precision highp image2D;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 layout(binding = 0, rgba8) writeonly uniform image2D imageOut;
 
-
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float  iTime;
 uniform vec2 iResolution;
 
@@ -1965,16 +2140,29 @@ float Voronoi(in vec2 p){
 
 void main() {
 
-	vec2 iResolution = vec2(1920.0, 1080.0);
+    vec2 iResolution = vec2(1920.0, 1080.0);
     ivec2 id = ivec2(gl_GlobalInvocationID.xy);
-
+ float tm = (iTime / 2.) * 0.0125;
+ 
 
 
     // Unit directional ray - Coyote's observation.
     vec3 rd = normalize(vec3(2. * vec2(id) - iResolution.xy, iResolution.y));
 
 
-    float tm = (iTime / 2.) * 0.0125;
+      ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
 
     // Rotate the XY-plane back and forth. Note that sine and cosine are kind of rolled into one.
     vec2 a = sin(vec2(1.570796, 0) + sin(tm / 4.) * .3);
@@ -2079,7 +2267,7 @@ vec3 ro = vec3(0.0,0.0, 0.);
     // Applying the shades.
     col *= (atten*crv*ao);
 
-col *= 2.0;
+col *= 1.3;
  // Rough gamma correction, then write to the output buffer.
     vec3 finalColor = sqrt(clamp(col, 0., 1.));
     ivec2 fragCoord = ivec2(id);  // Convert to ivec2
@@ -2093,7 +2281,7 @@ col *= 2.0;
 static const char *render_source_neon_pattern  =
     R"(
 
- #version 320 es
+ #version 310 es
 precision highp float;
 precision highp image2D;
 
@@ -2102,6 +2290,11 @@ layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
 //uniform float current_time;  // Assuming this is the global time variable
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+
 layout(location = 9) uniform float current_time; 
 
 vec3 palette(float t) {
@@ -2115,6 +2308,18 @@ vec3 palette(float t) {
 void main() {
     ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
 
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
     vec2 uv = vec2(pos) / vec2(800, 600);
     vec2 uv0 = uv;
     vec3 finalColor = vec3(0.0);
@@ -2143,7 +2348,7 @@ void main() {
 
 static const char *render_source_neon_rings  =
     R"(
-#version 320 es
+#version 310 es
 precision highp float;
 precision highp image2D;
 
@@ -2151,16 +2356,30 @@ layout(binding = 0, rgba32f) uniform readonly image2D in_tex;
 layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
-layout(location = 3) uniform int width;
-layout(location = 4) uniform int height;
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
 layout(location = 9) uniform float current_time; // Animated time
 
 #define PI 3.14159265358979323846
 #define TWO_PI 6.28318530717958647692
 
 void main() {
-    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+   
+  ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
 
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
     // Number of circles
     int numCircles = 5;
 
@@ -2217,6 +2436,507 @@ void main() {
 )";
 
 
+static const char *render_source_deco  =
+    R"(
+#version 320 es
+precision highp float;
+precision highp image2D;
+
+layout(binding = 0, rgba32f) uniform readonly image2D in_tex;
+layout(binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+layout(location = 9) uniform float current_time;
+
+vec3 effect(float speed, vec2 uv, float time, float scale) {
+    float t = mod(time * 0.005, 6.0);
+    float rt = 0.00000000000001 * sin(t * 0.45);
+
+    mat2 m1 = mat2(cos(rt), -sin(rt), -sin(rt), cos(rt));
+    vec2 uva = uv * m1 * scale;
+    float irt = 0.005 * cos(t * 0.05);
+    mat2 m2 = mat2(sin(irt), cos(irt), -cos(irt), sin(irt));
+
+    for (int i = 1; i < 400; i += 1) {
+        float it = float(i);
+        uva *= m2;
+        uva.y += -1.0 + (0.6 / it) * cos(t + it * uva.x + 0.5 * it) * float(mod(it, 0.5) == 0.0);
+        uva.x += 1.0 + (0.5 / it) * cos(t + it * uva.y * 0.1 / 5.0 + 0.5 * (it + 15.0));  // Adjust the scaling factor for y-coordinate
+    }
+
+    float n = 0.5;
+    float r = n + n * sin(4.0 * uva.x + t);
+    float gb = n + n * sin(3.0 * uva.y);
+    return vec3(r, gb * 0.8 * r, gb * r);
+}
+
+void main() {
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 globalID = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy);
+    
+vec2 uv = vec2(pos) / vec2(1000, 2000);
+    uv = 2.0 * uv - 1.0;
+    uv *= (10.3 + 0.1 * sin(current_time * 0.01));
+
+       // Extract x and y coordinates
+    int x = globalID.x;
+    int y = globalID.y;
+
+    // Check if the pixel should be drawn
+    if (x <= 0 || y <= 0 || x >= width - 1 || y >= height - 1 ||
+        (x >= border_size && x <= width - border_size && y >= title_height && y <= height - border_size))
+    {
+        return;
+    }
+
+    
+   // uv.y -= current_time * 0.013;
+//uv.x -= current_time * 0.026;
+    vec3 col = effect(0.001, uv, current_time, 0.5);
+    // col += effect(0.5, uv * 3.0, 2.0 * current_time + 10.0, 0.5) * 0.3;
+    // col += effect(0.5, sin(current_time * 0.01) * uv * 2.0, 2.0 * current_time + 10.0, 0.5) * 0.1;
+
+    // Output the final color to the output texture
+    imageStore(out_tex, pos, vec4(col, 1.0));
+}
+)";
+
+/*
+static const char *render_source_overlay  =
+    R"(
+#version 320 es
+
+
+
+uniform vec2 iResolution;
+uniform float iTime;
+uniform vec2 iMouse;
+
+layout(binding = 0, rgba32f) readonly uniform highp image2D neural_network_tex;  // Use binding point 0
+layout(binding = 0, rgba32f) writeonly uniform highp image2D image;  // Use binding point 0
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+#define MARKER_RADIUS 12.5
+#define THICCNESS 2.0
+
+
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+
+float sin01(float x) {
+    return (sin(x) + 1.0) / 2.0;
+}
+
+void main() {
+    ivec2 storePos = ivec2(gl_GlobalInvocationID.xy);
+    vec2 fragCoord = vec2(storePos);
+
+    vec4 col = vec4(0.0);
+
+    vec2 p1 = vec2(0.0+THICCNESS , float(height)-THICCNESS );
+    vec2 p2 = vec2(0.0+THICCNESS , 0.0+THICCNESS );
+    
+    vec2 x1 = vec2(float(width)-THICCNESS , float(height)-THICCNESS );
+    vec2 x2 = vec2(float(width)-THICCNESS , 0.0+THICCNESS );
+    
+    vec2 y1 = vec2(0.0+THICCNESS , float(height)-THICCNESS );
+    vec2 y2 = vec2(float(width)-THICCNESS , float(height)-THICCNESS );
+
+    vec2 z1 = vec2(0.0+THICCNESS , 0.0+THICCNESS );
+    vec2 z2 = vec2(float(width)-THICCNESS , 0.0+THICCNESS );
+
+    vec2 p3 = fragCoord;
+    vec2 p12 = p2 - p1;
+    vec2 p13 = p3 - p1;
+    
+    vec2 x3 = fragCoord;
+    vec2 x12 = x2 - x1;
+    vec2 x13 = x3 - x1;
+    
+    vec2 y3 = fragCoord;
+    vec2 y12 = y2 - y1;
+    vec2 y13 = y3 - y1;
+    
+    vec2 z3 = fragCoord;
+    vec2 z12 = z2 - z1;
+    vec2 z13 = z3 - z1;
+    
+    
+    float d = dot(p12, p13) / length(p12); // = length(p13) * cos(angle)
+    float dx = dot(x12, x13) / length(x12);
+    float dy = dot(y12, y13) / length(y12);
+    float dz = dot(z12, z13) / length(z12);
+    
+    vec2 p4 = p1 + normalize(p12) * d;
+    vec2 x4 = x1 + normalize(x12) * dx;
+    vec2 y4 = y1 + normalize(y12) * dy;
+    vec2 z4 = z1 + normalize(z12) * dz;
+    
+   if (((length(p4 - p3) < THICCNESS && length(p4 - p1) <= length(p12) && length(p4 - p2) <= length(p12)) ||
+         (length(x4 - x3) < THICCNESS && length(x4 - x1) <= length(x12) && length(x4 - x2) <= length(x12))) ||
+         (length(y4 - y3) < THICCNESS && length(y4 - y1) <= length(y12) && length(y4 - y2) <= length(y12)) ||
+         (length(z4 - z3) < THICCNESS && length(z4 - z1) <= length(z12) && length(z4 - z2) <= length(z12))) {
+        col += vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+    // Draw the lines connecting the points
+    if (length(fragCoord - p1) < THICCNESS || length(fragCoord - p2) < THICCNESS ||
+        length(fragCoord - x1) < THICCNESS || length(fragCoord - x2) < THICCNESS ||
+        length(fragCoord - y1) < THICCNESS || length(fragCoord - y2) < THICCNESS ||
+        length(fragCoord - z1) < THICCNESS || length(fragCoord - z2) < THICCNESS) {
+        col += vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+   
+   //     vec4 neuralColor = imageLoad(neural_network_tex, ivec2(fragCoord));
+      
+     //   col = mix(col, neuralColor, 0.5);  // Example: simple linear interpolation (blend) with equal weight
+    vec4 neuralColor = imageLoad(neural_network_tex, ivec2(fragCoord));
+    col += neuralColor;
+
+    imageStore(image, storePos, col);
+}
+
+
+)";
+*/
+static const char *render_source_overlay  =
+    R"(
+#version 320 es
+
+
+
+uniform vec2 iResolution;
+uniform float iTime;
+uniform vec2 iMouse;
+
+
+
+layout(binding = 0, rgba32f) readonly uniform highp image2D neural_network_tex;  // Use binding point 0
+layout(binding = 0, rgba32f) writeonly uniform highp image2D image;  // Use binding point 0
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+#define MARKER_RADIUS 12.5
+#define THICCNESS 2.0
+
+
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+
+bool isInsideTriangle(vec2 p, vec2 a, vec2 b, vec2 c) {
+    vec2 v0 = b - a;
+    vec2 v1 = c - a;
+    vec2 v2 = p - a;
+
+    float dot00 = dot(v0, v0);
+    float dot01 = dot(v0, v1);
+    float dot02 = dot(v0, v2);
+    float dot11 = dot(v1, v1);
+    float dot12 = dot(v1, v2);
+
+    float invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
+    float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+
+    return (u >= 0.0) && (v >= 0.0) && (u + v <= 1.0);
+}
+
+
+vec4 toBezier(float delta, int i, vec4 P0, vec4 P1, vec4 P2, vec4 P3)
+{
+    float t = delta * float(i);
+    float t2 = t * t;
+    float one_minus_t = 1.0 - t;
+    float one_minus_t2 = one_minus_t * one_minus_t;
+    return (P0 * one_minus_t2 * one_minus_t + P1 * 3.0 * t * one_minus_t2 + P2 * 3.0 * t2 * one_minus_t + P3 * t2 * t);
+}
+
+float sin01(float x) {
+    return (sin(x) + 1.0) / 2.0;
+}
+
+
+
+vec4 drawCurveBenzier(vec2 p1, vec2 p2, int setCount) {
+    vec4 col = vec4(0.0);
+ ivec2 storePos = ivec2(gl_GlobalInvocationID.xy);
+  float curveRadius = 5.0;
+// Draw the lines connecting the points
+
+    vec2 fragCoord = vec2(storePos);
+    for (int i = 0; i <= setCount; ++i) {
+        vec4 bezierPoint = toBezier(1.0 / float(setCount), i, vec4(p1, 0.0, 1.0), vec4(p1 + (p2 - p1) * 0.5, 0.0, 1.0), vec4(p1 + (p2 - p1) * 0.5, 0.0, 1.0), vec4(p2, 0.0, 1.0));
+        vec2 curvePoint = bezierPoint.xy / bezierPoint.w;
+        float distance = length(fragCoord - curvePoint);
+        float curveIntensity = smoothstep(0.0, THICCNESS, curveRadius - distance);
+        col.rgb += vec3(0.1, 0.1, 0.1) * curveIntensity;
+        col.a = max(col.a, curveIntensity);
+    }
+
+    return col;
+}
+
+
+
+
+vec4 drawCurve(vec2 p1, vec2 p2, int setCount) {
+    vec4 col = vec4(0.0);
+    ivec2 storePos = ivec2(gl_GlobalInvocationID.xy);
+    float curveRadius = 6.0;
+    vec2 fragCoord = vec2(storePos);
+
+    float t = clamp(dot(fragCoord - p1, p2 - p1) / dot(p2 - p1, p2 - p1), 0.0, 1.0);
+    vec2 curvePoint = mix(p1, p2, t);
+
+    float distance = length(fragCoord - curvePoint);
+    float curveIntensity = smoothstep(0.0, curveRadius, curveRadius - distance);
+
+    // Calculate gradient along the line with grey to white to grey
+    vec3 gradientColor;
+
+    if (t < 0.5) {
+        gradientColor = mix(vec3(0.7), vec3(1.0), t * 2.0);
+    } else {
+        gradientColor = mix(vec3(1.0), vec3(0.7), (t - 0.5) * 2.0);
+    }
+
+    // Use the curveIntensity to interpolate between gradient colors
+    col.rgb = gradientColor * curveIntensity;
+    col.a = max(col.a, curveIntensity);
+
+    return col;
+}
+
+void main() {
+    ivec2 storePos = ivec2(gl_GlobalInvocationID.xy);
+    vec2 fragCoord = vec2(storePos);
+
+ vec4 col = vec4(0.0);
+    float space = 15.0; 
+
+    vec2 p1 = vec2(0.0 + THICCNESS, float(height) - THICCNESS - space);
+    vec2 p2 = vec2(0.0 + THICCNESS, 0.0 + THICCNESS + space);
+
+    vec2 x1 = vec2(float(width) - THICCNESS, float(height) - THICCNESS - space);
+    vec2 x2 = vec2(float(width) - THICCNESS, 0.0 + THICCNESS + space);
+
+    vec2 y1 = vec2(0.0 + THICCNESS + space, float(height) - THICCNESS);
+    vec2 y2 = vec2(float(width) - THICCNESS - space, float(height) - THICCNESS);
+
+    vec2 z1 = vec2(0.0 + THICCNESS + space, 0.0 + THICCNESS);
+    vec2 z2 = vec2(float(width) - THICCNESS - space, 0.0 + THICCNESS);
+
+ float curveRadius = 5.0;
+// Draw the lines connecting the points
+
+int setwidth = int(width);
+int setheight = int(height);
+
+
+if (setwidth<=400 && setheight<=300 ){
+ 	col += drawCurveBenzier(p1, p2, setheight);
+    col += drawCurveBenzier(x1, x2, setheight);
+    col += drawCurveBenzier(y1, y2, setwidth);
+    col += drawCurveBenzier(z1, z2, setwidth);
+}
+else {
+    col += drawCurve(p1, p2, setheight);
+    col += drawCurve(x1, x2, setheight);
+    col += drawCurve(y1, y2, setwidth);
+    col += drawCurve(z1, z2, setwidth);
+	}
+
+
+float INNERspace = 0.0; 
+
+
+//left
+    vec2 INNERp1 = vec2(0.0 - THICCNESS+ float(border_size)/2.0, float(height)  - THICCNESS - INNERspace-float(border_size)/2.0 );
+    vec2 INNERp2 = vec2(0.0 - THICCNESS+ float(border_size)/2.0,0.0 - THICCNESS + INNERspace+float(border_size)/2.0 +float(title_height-border_size));
+//right     
+    vec2 INNERx1 = vec2(float(width) + THICCNESS-float(border_size)/2.0, float(height)- THICCNESS - INNERspace-float(border_size)/2.0);
+    vec2 INNERx2 = vec2(float(width) + THICCNESS-float(border_size)/2.0,0.0 - THICCNESS + INNERspace+float(border_size)/2.0 +float(title_height-border_size));
+//bottom
+    vec2 INNERy1 = vec2(0.0 + THICCNESS + INNERspace+float(border_size)/2.0, float(height)   + THICCNESS -float(border_size)/2.0);
+    vec2 INNERy2 = vec2(float(width) - THICCNESS - INNERspace-float(border_size)/2.0, float(height) + THICCNESS-float(border_size)/2.0);
+//top
+   vec2 INNERz1 = vec2(0.0 +INNERspace+float(border_size)/2.0, 0.0 - THICCNESS + INNERspace+float(border_size)/2.0 +float(title_height-border_size));
+    vec2 INNERz2 = vec2(float(width) - THICCNESS - INNERspace-float(border_size)/2.0 ,0.0 - THICCNESS + INNERspace+float(border_size)/2.0 +float(title_height-border_size));
+
+
+
+if (setwidth<=400 && setheight<=300 ){
+ 	col += drawCurveBenzier(INNERp1, INNERp2, setheight);
+    col += drawCurveBenzier(INNERx1, INNERx2, setheight);
+    col += drawCurveBenzier(INNERy1, INNERy2, setwidth);
+    col += drawCurveBenzier(INNERz1, INNERz2, setwidth);
+}
+else{
+    col += drawCurve(INNERp1, INNERp2, setheight);
+    col += drawCurve(INNERx1, INNERx2, setheight);
+    col += drawCurve(INNERy1, INNERy2, setwidth);
+    col += drawCurve(INNERz1, INNERz2, setwidth);
+    }
+
+
+    vec2 p3 = fragCoord;
+    vec2 p12 = p2 - p1;
+    vec2 p13 = p3 - p1;
+
+    vec2 x3 = fragCoord;
+    vec2 x12 = x2 - x1;
+    vec2 x13 = x3 - x1;
+
+    vec2 y3 = fragCoord;
+    vec2 y12 = y2 - y1;
+    vec2 y13 = y3 - y1;
+
+    vec2 z3 = fragCoord;
+    vec2 z12 = z2 - z1;
+    vec2 z13 = z3 - z1;
+
+    float d = dot(p12, p13) / length(p12); // = length(p13) * cos(angle)
+    float dx = dot(x12, x13) / length(x12);
+    float dy = dot(y12, y13) / length(y12);
+    float dz = dot(z12, z13) / length(z12);
+
+    vec2 p4 = p1 + normalize(p12) * d;
+    vec2 x4 = x1 + normalize(x12) * dx;
+    vec2 y4 = y1 + normalize(y12) * dy;
+    vec2 z4 = z1 + normalize(z12) * dz;
+    
+       if (((length(p4 - p3) < THICCNESS && length(p4 - p1) <= length(p12) && length(p4 - p2) <= length(p12)) ||
+         (length(x4 - x3) < THICCNESS && length(x4 - x1) <= length(x12) && length(x4 - x2) <= length(x12))) ||
+         (length(y4 - y3) < THICCNESS && length(y4 - y1) <= length(y12) && length(y4 - y2) <= length(y12)) ||
+         (length(z4 - z3) < THICCNESS && length(z4 - z1) <= length(z12) && length(z4 - z2) <= length(z12))) { 
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+    
+    
+    vec2 INNERp3 = fragCoord;
+    vec2 INNERp12 = INNERp2 - INNERp1;
+    vec2 INNERp13 = INNERp3 - INNERp1;
+
+    vec2 INNERx3 = fragCoord;
+    vec2 INNERx12 = INNERx2 - INNERx1;
+    vec2 INNERx13 = INNERx3 - INNERx1;
+
+    vec2 INNERy3 = fragCoord;
+    vec2 INNERy12 = INNERy2 - INNERy1;
+    vec2 INNERy13 = INNERy3 - INNERy1;
+
+    vec2 INNERz3 = fragCoord;
+    vec2 INNERz12 = INNERz2 - INNERz1;
+    vec2 INNERz13 = INNERz3 - INNERz1;
+
+    float INNERd = dot(INNERp12, INNERp13) / length(INNERp12); // = length(p13) * cos(angle)
+    float INNERdx = dot(INNERx12, INNERx13) / length(INNERx12);
+    float INNERdy = dot(INNERy12, INNERy13) / length(INNERy12);
+    float INNERdz = dot(INNERz12, INNERz13) / length(INNERz12);
+
+    vec2 INNERp4 = INNERp1 + normalize(INNERp12) * INNERd;
+    vec2 INNERx4 = INNERx1 + normalize(INNERx12) * INNERdx;
+    vec2 INNERy4 = INNERy1 + normalize(INNERy12) * INNERdy;
+    vec2 INNERz4 = INNERz1 + normalize(INNERz12) * INNERdz;
+    
+       if (((length(INNERp4 - INNERp3) < THICCNESS && length(INNERp4 - INNERp1) <= length(INNERp12) && length(INNERp4 - INNERp2) <= length(INNERp12)) ||
+         (length(INNERx4 - INNERx3) < THICCNESS && length(INNERx4 - INNERx1) <= length(INNERx12) && length(INNERx4 - INNERx2) <= length(INNERx12))) ||
+         (length(INNERy4 - INNERy3) < THICCNESS && length(INNERy4 - INNERy1) <= length(INNERy12) && length(INNERy4 - INNERy2) <= length(INNERy12)) ||
+         (length(INNERz4 - INNERz3) < THICCNESS && length(INNERz4 - INNERz1) <= length(INNERz12) && length(INNERz4 - INNERz2) <= length(INNERz12))) { 
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }    
+
+    
+
+
+
+    // Draw the lines connecting the points
+       // Calculate the line segment connecting p1 and y1
+    vec2 dir = normalize(y1 - p1);
+    vec2 relPoint = fragCoord - p1;
+    float alongLine = dot(relPoint, dir);
+    float distance = length(relPoint - alongLine * dir);
+
+    // Draw the line connecting p1 and y1
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(y1 - p1)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+
+    
+    dir = normalize(y2 - x1);
+    relPoint = fragCoord - x1;
+     alongLine = dot(relPoint, dir);
+     distance = length(relPoint - alongLine * dir);
+
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(x1 - y2)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+
+ dir = normalize(p2 - z1);
+    relPoint = fragCoord - z1;
+     alongLine = dot(relPoint, dir);
+     distance = length(relPoint - alongLine * dir);
+
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(z1 - p2)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+
+
+ dir = normalize(x2 - z2);
+    relPoint = fragCoord - z2;
+     alongLine = dot(relPoint, dir);
+     distance = length(relPoint - alongLine * dir);
+
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(x2 - z2)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+    // Draw other lines...
+
+    vec2 t1 = vec2(0.0, float(height));
+    vec2 t2 = vec2(float(width), float(height));
+    vec2 t3 = vec2(-0.5, -0.5);
+    vec2 t4 = vec2(float(width), -0.5);
+
+
+   if (isInsideTriangle(fragCoord, vec2(p1.x-10.1,p1.y), t1, vec2(y1.x,y1.y+10.1))  ||
+        isInsideTriangle(fragCoord, vec2(x1.x+10.1,x1.y), t2, vec2(y2.x,y2.y+10.1))  ||
+        isInsideTriangle(fragCoord, vec2(z1.x,z1.y-2.4), t3, vec2(p2.x-3.1,p2.y-2.1)) ||
+        isInsideTriangle(fragCoord, vec2(z2.x,z2.y-5.5), t4, vec2(x2.x+3.1,x2.y)) ) {
+        col = vec4(0.0, 0.0, 0.0, 0.0);  // Set the color to fully transparent
+    } else {
+        // Apply your original logic for other regions
+
+        // Sample neural network texture
+        vec4 neuralColor = imageLoad(neural_network_tex, ivec2(fragCoord));
+        col += neuralColor;
+    }
+//z2 - x2
+
+  //    vec4 neuralColor = imageLoad(neural_network_tex, ivec2(fragCoord));
+   //     col += neuralColor;
+    // Store the final color
+    imageStore(image, storePos, col);
+}
+
+)";
+
+
+
+
+
 void setup_shader(GLuint *program, std::string source)
 {
     auto compute_shader  = OpenGL::compile_shader(source.c_str(), GL_COMPUTE_SHADER);
@@ -2251,6 +2971,10 @@ wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
 smoke_t::smoke_t()
 {
     OpenGL::render_begin();
+  
+
+if (std::string(effect_type) == "smoke" || std::string(effect_type) == "ink" )
+{
     setup_shader(&motion_program, motion_source);
     setup_shader(&diffuse1_program, diffuse1_source);
     setup_shader(&diffuse2_program, diffuse2_source);
@@ -2264,7 +2988,9 @@ smoke_t::smoke_t()
     setup_shader(&advect2_program, advect2_source);
 
     setup_shader(&render_program, render_source);
-    
+}   
+
+
  	if (std::string(effect_type) == "clouds")
  	{
    	setup_shader(&render_program, render_source_clouds);
@@ -2309,7 +3035,12 @@ smoke_t::smoke_t()
  	{
    	setup_shader(&render_program, render_source_neon_rings );
 	}
+	else if (std::string(effect_type) == "deco")
+ 	{
+   	setup_shader(&render_program, render_source_deco);
+   	}
 
+   		setup_shader(&render_overlay_program, render_source_overlay);
  
     texture = b0u = b0v = b0d = b1u = b1v = b1d = GLuint(-1);
     OpenGL::render_end();
@@ -2317,6 +3048,9 @@ smoke_t::smoke_t()
 }
 
 smoke_t::~smoke_t()
+{
+ 
+if (std::string(effect_type) == "smoke" || std::string(effect_type) == "ink" )
 {
     GL_CALL(glDeleteProgram(motion_program));
     GL_CALL(glDeleteProgram(diffuse1_program));
@@ -2329,9 +3063,9 @@ smoke_t::~smoke_t()
     GL_CALL(glDeleteProgram(project6_program));
     GL_CALL(glDeleteProgram(advect1_program));
     GL_CALL(glDeleteProgram(advect2_program));
-
+}
     GL_CALL(glDeleteProgram(render_program));
-    
+    GL_CALL(glDeleteProgram(render_overlay_program));
     destroy_textures();
 }
 
@@ -2362,12 +3096,22 @@ void smoke_t::destroy_textures()
     GL_CALL(glDeleteTextures(1, &b1d));
 }
 
+
+
+
 void smoke_t::run_shader(GLuint program, int width, int height, int title_height, int border_size)
 {
     GL_CALL(glUseProgram(program));
+  
+
+ GL_CALL(glUniform1i(glGetUniformLocation(program, "neural_network_tex"), 0));
+
+GL_CALL(glDispatchCompute(width / 15, height / 15, 1));
+GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
     GL_CALL(glActiveTexture(GL_TEXTURE0 + 1));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, b0u));
     GL_CALL(glBindImageTexture(1, b0u, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+ 
     GL_CALL(glActiveTexture(GL_TEXTURE0 + 2));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, b0v));
     GL_CALL(glBindImageTexture(2, b0v, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
@@ -2486,6 +3230,10 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
     GL_CALL(glUniform1i(8, random()));
     GL_CALL(glDispatchCompute(rectangle.width / 15, rectangle.height / 15, 1));
     GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
+ 
+if (std::string(effect_type) == "smoke" || std::string(effect_type) == "ink" )
+{
+
     for (int k = 0; k < diffuse_iterations; k++)
     {
         run_shader(diffuse1_program, rectangle.width, rectangle.height, title_height, border_size);
@@ -2512,7 +3260,7 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
     }
 
     run_shader(advect2_program, rectangle.width, rectangle.height, title_height, border_size);
-   
+ }  
     GL_CALL(glUseProgram(render_program));
     GL_CALL(glActiveTexture(GL_TEXTURE0 + 0));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
@@ -2520,6 +3268,8 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
     GL_CALL(glActiveTexture(GL_TEXTURE0 + 3));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, b0d));
     GL_CALL(glBindImageTexture(3, b0d, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+
+
     GLfloat effect_color_f[4] =
     {GLfloat(effect_color.r), GLfloat(effect_color.g), GLfloat(effect_color.b),
         GLfloat(effect_color.a)};
@@ -2552,6 +3302,165 @@ void smoke_t::step_effect(const wf::render_target_t& fb, wf::geometry_t rectangl
     GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
     GL_CALL(glUseProgram(0));
     OpenGL::render_end();
+
+
+ OpenGL::render_begin(fb);
+    if ((rectangle.width != saved_width) || (rectangle.height != saved_height))
+    {
+        LOGI("recreating smoke textures: ", rectangle.width, " != ", saved_width, " || ", rectangle.height,
+            " != ", saved_height);
+        saved_width  = rectangle.width;
+        saved_height = rectangle.height;
+
+        destroy_textures();
+        create_textures();
+
+        std::vector<GLfloat> clear_data(rectangle.width * rectangle.height * 4, 0);
+
+        GL_CALL(glActiveTexture(GL_TEXTURE0 + 0));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA32F, rectangle.width, rectangle.height));
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rectangle.width, rectangle.height, GL_RGBA, GL_FLOAT,
+            &clear_data[0]);
+        GL_CALL(glActiveTexture(GL_TEXTURE0 + 1));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, b0u));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32F, rectangle.width, rectangle.height));
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rectangle.width, rectangle.height, GL_RED, GL_FLOAT,
+            &clear_data[0]);
+        GL_CALL(glActiveTexture(GL_TEXTURE0 + 2));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, b0v));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32F, rectangle.width, rectangle.height));
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rectangle.width, rectangle.height, GL_RED, GL_FLOAT,
+            &clear_data[0]);
+        GL_CALL(glActiveTexture(GL_TEXTURE0 + 3));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, b0d));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32F, rectangle.width, rectangle.height));
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rectangle.width, rectangle.height, GL_RED, GL_FLOAT,
+            &clear_data[0]);
+        GL_CALL(glActiveTexture(GL_TEXTURE0 + 4));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, b1u));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32F, rectangle.width, rectangle.height));
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rectangle.width, rectangle.height, GL_RED, GL_FLOAT,
+            &clear_data[0]);
+        GL_CALL(glActiveTexture(GL_TEXTURE0 + 5));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, b1v));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32F, rectangle.width, rectangle.height));
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rectangle.width, rectangle.height, GL_RED, GL_FLOAT,
+            &clear_data[0]);
+        GL_CALL(glActiveTexture(GL_TEXTURE0 + 6));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, b1d));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_R32F, rectangle.width, rectangle.height));
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rectangle.width, rectangle.height, GL_RED, GL_FLOAT,
+            &clear_data[0]);
+    }
+
+  /*  GL_CALL(glUseProgram(motion_program));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 1));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b0u));
+    GL_CALL(glBindImageTexture(1, b0u, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 2));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b0v));
+    GL_CALL(glBindImageTexture(2, b0v, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 3));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b0d));
+    GL_CALL(glBindImageTexture(3, b0d, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+    */
+    //wf::point_t point{int(p.x), int(p.y)};
+    // upload stuff
+    GL_CALL(glUniform1i(1, title_height + border_size));
+    GL_CALL(glUniform1i(2, border_size));
+    GL_CALL(glUniform1i(3, point.x));
+    GL_CALL(glUniform1i(4, point.y));
+    GL_CALL(glUniform1i(5, rectangle.width));
+    GL_CALL(glUniform1i(6, rectangle.height));
+    GL_CALL(glUniform1i(7, random()));
+    GL_CALL(glUniform1i(8, random()));
+    GL_CALL(glDispatchCompute(rectangle.width / 15, rectangle.height / 15, 1));
+    GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
+/*    for (int k = 0; k < diffuse_iterations; k++)
+    {
+        run_shader(diffuse1_program, rectangle.width, rectangle.height, title_height, border_size);
+    }
+
+    run_shader(project1_program, rectangle.width, rectangle.height, title_height, border_size);
+    for (int k = 0; k < diffuse_iterations; k++)
+    {
+        run_shader(project2_program, rectangle.width, rectangle.height, title_height, border_size);
+    }
+
+    run_shader(project3_program, rectangle.width, rectangle.height, title_height, border_size);
+    run_shader(advect1_program, rectangle.width, rectangle.height, title_height, border_size);
+    run_shader(project4_program, rectangle.width, rectangle.height, title_height, border_size);
+    for (int k = 0; k < diffuse_iterations; k++)
+    {
+        run_shader(project5_program, rectangle.width, rectangle.height, title_height, border_size);
+    }
+
+    run_shader(project6_program, rectangle.width, rectangle.height, title_height, border_size);
+    for (int k = 0; k < diffuse_iterations; k++)
+    {
+        run_shader(diffuse2_program, rectangle.width, rectangle.height, title_height, border_size);
+    }
+
+    run_shader(advect2_program, rectangle.width, rectangle.height, title_height, border_size);
+  */ 
+    GL_CALL(glUseProgram(render_overlay_program));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 0));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
+    GL_CALL(glBindImageTexture(0, texture, 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA32F));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 3));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, b0d));
+    GL_CALL(glBindImageTexture(3, b0d, 0, GL_FALSE, 0, GL_READ_WRITE, GL_R32F));
+
+
+   // GLfloat effect_color_f[4] =
+   // {GLfloat(effect_color.r), GLfloat(effect_color.g), GLfloat(effect_color.b),
+     //   GLfloat(effect_color.a)};
+ //   GLfloat decor_color_f[4] =
+   // {GLfloat(decor_color.r), GLfloat(decor_color.g), GLfloat(decor_color.b), GLfloat(decor_color.a)};
+    GL_CALL(glUniform1i(1, title_height + border_size * 2));
+    GL_CALL(glUniform1i(2, border_size * 2));
+    GL_CALL(glUniform1i(4, ink));
+    GL_CALL(glUniform1i(5, rectangle.width));
+    GL_CALL(glUniform1i(6, rectangle.height));
+    GL_CALL(glUniform4fv(7, 1, effect_color_f));
+    GL_CALL(glUniform4fv(8, 1, decor_color_f));
+    GL_CALL(glUniform1f(9, wf::get_current_time() / 30.0));
+
+    GL_CALL(glDispatchCompute(rectangle.width / 15, rectangle.height / 15, 1));
+    GL_CALL(glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 0));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 1));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 2));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 3));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 4));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 5));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glActiveTexture(GL_TEXTURE0 + 6));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glUseProgram(0));
+    OpenGL::render_end();
+
+
 }
 
 void smoke_t::render_effect(const wf::render_target_t& fb, wf::geometry_t rectangle,

--- a/src/deco-effects.hpp
+++ b/src/deco-effects.hpp
@@ -11,12 +11,12 @@ namespace decor
 class smoke_t
 {
     /** background effects */
-    GLuint motion_program,
+      GLuint motion_program,
         diffuse1_program, diffuse2_program,
         project1_program, project2_program, project3_program,
         project4_program, project5_program, project6_program,
-        advect1_program, advect2_program, render_program,
-        texture, b0u, b0v, b0d, b1u, b1v, b1d;
+        advect1_program, advect2_program, render_program, render_overlay_program,
+        texture, b0u, b0v, b0d, b1u, b1v, b1d, neural_network_tex;
 
     int saved_width = -1, saved_height = -1;
 

--- a/src/deco-effects.hpp
+++ b/src/deco-effects.hpp
@@ -1,37 +1,56 @@
 #pragma once
+#include <wayfire/option-wrapper.hpp>
 #include <wayfire/core.hpp>
 #include <wayfire/opengl.hpp>
-#include <map>
 #include <GLES3/gl32.h>
 
 namespace wf
 {
-namespace decor
+namespace pixdecor
 {
 class smoke_t
 {
     /** background effects */
-      GLuint motion_program,
+    GLuint motion_program,
         diffuse1_program, diffuse2_program,
         project1_program, project2_program, project3_program,
         project4_program, project5_program, project6_program,
         advect1_program, advect2_program, render_program, render_overlay_program,
         texture, b0u, b0v, b0d, b1u, b1v, b1d, neural_network_tex;
 
+    OpenGL::program_t fragment_effect_only_program{};
     int saved_width = -1, saved_height = -1;
+
+    wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
+    wf::option_wrapper_t<std::string> overlay_engine{"pixdecor/overlay_engine"};
+    wf::option_wrapper_t<std::string> compute_fragment_shader{"pixdecor/compute_fragment_shader"};
+    wf::option_wrapper_t<bool> effect_animate{"pixdecor/animate"};
+    wf::option_wrapper_t<int> rounded_corner_radius{"pixdecor/rounded_corner_radius"};
+    wf::option_wrapper_t<wf::color_t> shadow_color{"pixdecor/shadow_color"};
+    wf::option_wrapper_t<int> beveled_radius{"pixdecor/beveled_radius"};
+    int last_shadow_radius = 0;
 
   public:
     smoke_t();
     ~smoke_t();
 
-    void run_shader(GLuint program, int width, int height, int title_height, int border_size);
+    void run_shader(GLuint program, int width, int height, int title_height, int border_size, int radius, int beveled_radius);
+    void run_shader_region(GLuint program, const wf::region_t & region, const wf::dimensions_t & size);
+    void run_fragment_shader(const wf::render_target_t& fb,
+        wf::geometry_t rectangle, const wf::region_t& scissor,int border_size, int title_height);
+
+    void dispatch_region(const wf::region_t& region);
+
     void step_effect(const wf::render_target_t& fb, wf::geometry_t rectangle,
         bool ink, wf::pointf_t p, wf::color_t decor_color, wf::color_t effect_color,
-        int title_height, int border_size, int diffuse_iterations);
-    void render_effect(const wf::render_target_t& fb, wf::geometry_t rectangle,
-        const wf::geometry_t& scissor);
+        int title_height, int border_size, int shadow_radius);
+    void render_effect(const wf::render_target_t& fb, wf::geometry_t rectangle, const wf::region_t& scissor,int border_size,int title_height );
+    void recreate_textures(wf::geometry_t rectangle);
+    void create_programs();
+    void destroy_programs();
     void create_textures();
     void destroy_textures();
+    void effect_updated();
 };
 }
 }

--- a/src/deco-layout.hpp
+++ b/src/deco-layout.hpp
@@ -6,11 +6,12 @@
 
 namespace wf
 {
-namespace decor
+namespace pixdecor
 {
 static constexpr uint32_t DECORATION_AREA_RENDERABLE_BIT = (1 << 16);
 static constexpr uint32_t DECORATION_AREA_RESIZE_BIT     = (1 << 17);
-static constexpr uint32_t DECORATION_AREA_MOVE_BIT = (1 << 18);
+static constexpr uint32_t DECORATION_AREA_MOVE_BIT   = (1 << 18);
+static constexpr uint32_t DECORATION_AREA_SHADOW_BIT = (1 << 19);
 
 
 /** Different types of areas around the decoration */
@@ -20,6 +21,7 @@ enum decoration_area_type_t
     DECORATION_AREA_TITLE         =
         DECORATION_AREA_MOVE_BIT | DECORATION_AREA_RENDERABLE_BIT,
     DECORATION_AREA_BUTTON        = DECORATION_AREA_RENDERABLE_BIT,
+    DECORATION_AREA_SHADOW        = DECORATION_AREA_SHADOW_BIT,
     DECORATION_AREA_RESIZE_LEFT   = WLR_EDGE_LEFT | DECORATION_AREA_RESIZE_BIT,
     DECORATION_AREA_RESIZE_RIGHT  = WLR_EDGE_RIGHT | DECORATION_AREA_RESIZE_BIT,
     DECORATION_AREA_RESIZE_TOP    = WLR_EDGE_TOP | DECORATION_AREA_RESIZE_BIT,

--- a/src/deco-subsurface.cpp
+++ b/src/deco-subsurface.cpp
@@ -130,6 +130,8 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
                 view->damage();
             }
         });
+
+
         current_cursor_position.x = current_cursor_position.y = FLT_MIN;
     }
 

--- a/src/deco-subsurface.hpp
+++ b/src/deco-subsurface.hpp
@@ -23,6 +23,7 @@ class simple_decorator_t : public wf::custom_data_t
 
   public:
     void update_colors();
+    void damage(wayfire_view view);
     simple_decorator_t(wayfire_toplevel_view view);
     ~simple_decorator_t();
     wf::decoration_margins_t get_margins(const wf::toplevel_state_t& state);

--- a/src/deco-subsurface.hpp
+++ b/src/deco-subsurface.hpp
@@ -23,10 +23,11 @@ class simple_decorator_t : public wf::custom_data_t
 
   public:
     void update_colors();
-    void damage(wayfire_view view);
+    void effect_updated();
     simple_decorator_t(wayfire_toplevel_view view);
     ~simple_decorator_t();
     wf::decoration_margins_t get_margins(const wf::toplevel_state_t& state);
+    void update_animation();
 };
 }
 

--- a/src/deco-theme.cpp
+++ b/src/deco-theme.cpp
@@ -13,7 +13,7 @@ wf::option_wrapper_t<wf::color_t> fg_color{"pixdecor/fg_color"};
 wf::option_wrapper_t<wf::color_t> bg_color{"pixdecor/bg_color"};
 wf::option_wrapper_t<wf::color_t> fg_text_color{"pixdecor/fg_text_color"};
 wf::option_wrapper_t<wf::color_t> bg_text_color{"pixdecor/bg_text_color"};
-wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
+//wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
 wf::option_wrapper_t<wf::color_t> effect_color{"pixdecor/effect_color"};
 /** Create a new theme with the default parameters */
 decoration_theme_t::decoration_theme_t()
@@ -157,14 +157,14 @@ void decoration_theme_t::set_maximize(bool state)
 void decoration_theme_t::render_background(const wf::render_target_t& fb,
     wf::geometry_t rectangle, const wf::geometry_t& scissor, bool active, wf::pointf_t p)
 {
-    if (std::string(effect_type) == "none")
+ /*   if (std::string(effect_type) == "none")
     {
         OpenGL::render_begin(fb);
         fb.logic_scissor(scissor);
         OpenGL::render_rectangle(rectangle, get_decor_color(active), fb.get_orthographic_projection());
         OpenGL::render_end();
     } else
-    {
+   */ {
         smoke.render_effect(fb, rectangle, scissor);
     }
 }

--- a/src/deco-theme.cpp
+++ b/src/deco-theme.cpp
@@ -157,7 +157,7 @@ void decoration_theme_t::set_maximize(bool state)
 void decoration_theme_t::render_background(const wf::render_target_t& fb,
     wf::geometry_t rectangle, const wf::geometry_t& scissor, bool active, wf::pointf_t p)
 {
- /*   if (std::string(effect_type) == "none")
+/*    if (std::string(effect_type) == "none")
     {
         OpenGL::render_begin(fb);
         fb.logic_scissor(scissor);

--- a/src/deco-theme.hpp
+++ b/src/deco-theme.hpp
@@ -11,7 +11,7 @@
 
 namespace wf
 {
-namespace decor
+namespace pixdecor
 {
 /**
  * A  class which manages the outlook of decorations.
@@ -47,7 +47,7 @@ class decoration_theme_t
      * @param active Whether to use active or inactive colors
      */
     void render_background(const wf::render_target_t& fb,
-        wf::geometry_t rectangle, const wf::geometry_t& scissor, bool active, wf::pointf_t p);
+        wf::geometry_t rectangle, const wf::region_t& scissor, bool active, wf::pointf_t p,int border_size, int title_height);
 
     /**
      * Render the given text on a cairo_surface_t with the given size.

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -6,6 +6,7 @@
 #include <wayfire/output.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/txn/transaction-manager.hpp>
+#include <wayfire/render-manager.hpp>
 
 #include "deco-subsurface.hpp"
 #include "wayfire/core.hpp"
@@ -46,6 +47,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
     wf::option_wrapper_t<wf::color_t> bg_text_color{"pixdecor/bg_text_color"};
     wf::option_wrapper_t<std::string> ignore_views_string{"pixdecor/ignore_views"};
     wf::option_wrapper_t<std::string> always_decorate_string{"pixdecor/always_decorate"};
+    wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
     wf::view_matcher_t ignore_views{"pixdecor/ignore_views"};
     wf::view_matcher_t always_decorate{"pixdecor/always_decorate"};
     wf::wl_idle_call idle_update_views;
@@ -54,6 +56,9 @@ class wayfire_pixdecor : public wf::plugin_interface_t
     int wd_cfg_dir;
     wl_event_source *evsrc;
     std::function<void(void)> update_event;
+    wf::effect_hook_t pre_hook;
+    wf::output_t *output;
+    bool hook_set = false;
 
     wf::signal::connection_t<wf::txn::new_transaction_signal> on_new_tx =
         [=] (wf::txn::new_transaction_signal *ev)
@@ -160,6 +165,61 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             });
         });
 
+        pre_hook = [=] ()
+        {
+            for (auto& view : wf::get_core().get_all_views())
+            {
+                auto toplevel = wf::toplevel_cast(view);
+                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                {
+                    continue;
+                }
+                toplevel->toplevel()->get_data<wf::simple_decorator_t>()->damage(view);
+            }
+        };
+
+        if (std::string(effect_type) != "none")
+        {
+            for (auto& o : wf::get_core().output_layout->get_outputs())
+            {
+                o->render->add_effect(&pre_hook, wf::OUTPUT_EFFECT_PRE);
+            }
+        }
+
+        effect_type.set_callback([=] ()
+        {
+            if (std::string(effect_type) == "none")
+            {
+                if (hook_set)
+                {
+                    for (auto& o : wf::get_core().output_layout->get_outputs())
+                    {
+                        o->render->rem_effect(&pre_hook);
+                    }
+                    hook_set = false;
+                }
+            } else
+            {
+                if (!hook_set)
+                {
+                    for (auto& o : wf::get_core().output_layout->get_outputs())
+                    {
+                        o->render->add_effect(&pre_hook, wf::OUTPUT_EFFECT_PRE);
+                    }
+                    hook_set = true;
+                }
+            }
+            for (auto& view : wf::get_core().get_all_views())
+            {
+                auto toplevel = wf::toplevel_cast(view);
+                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                {
+                    continue;
+                }
+                toplevel->toplevel()->get_data<wf::simple_decorator_t>()->damage(view);
+            }
+        });
+
         // set up the watch on the xsettings file
         inotify_fd = inotify_init1(IN_CLOEXEC);
         evsrc = wl_event_loop_add_fd(wf::get_core().ev_loop, inotify_fd, WL_EVENT_READABLE,
@@ -187,6 +247,13 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             {
                 remove_decoration(toplevel);
                 wf::get_core().tx_manager->schedule_object(toplevel->toplevel());
+            }
+        }
+        if (hook_set)
+        {
+            for (auto& o : wf::get_core().output_layout->get_outputs())
+            {
+                o->render->rem_effect(&pre_hook);
             }
         }
 

--- a/src/effect-shaders.hpp
+++ b/src/effect-shaders.hpp
@@ -1,0 +1,1487 @@
+static const char *generic_effect_vertex_shader = R"(
+#version 320 es
+
+in highp vec2 position;
+out highp vec2 relativePosition;
+
+uniform mat4 MVP;
+uniform vec2 topLeftCorner;
+
+void main() {
+    relativePosition = position.xy - topLeftCorner;
+    gl_Position = MVP * vec4(position.xy, 0.0, 1.0);
+})";
+
+static const char *generic_effect_fragment_header = R"(
+#version 320 es
+precision highp float;
+precision highp image2D;
+
+in highp vec2 relativePosition;
+uniform float current_time;
+uniform float width;
+uniform float height;
+
+
+
+out vec4 fragColor;
+)";
+
+static const char *generic_effect_fragment_main = R"(
+void main()
+{
+    fragColor = overlay_function(relativePosition);
+})";
+
+// ported from https://www.shadertoy.com/view/WdXBW4
+static const char *effect_clouds_fragment = R"(
+float cloudscale=2.1;  // Added cloudscale parameter
+const mat2 m = mat2(1.6, 1.2, -1.2, 1.6);
+
+vec2 hash(vec2 p) {
+    p = vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)));
+    return -1.0 + 2.0 * fract(sin(p) * 43758.5453123);
+}
+
+float noise(vec2 p) {
+    const float K1 = 0.366025404; // (sqrt(3)-1)/2;
+    const float K2 = 0.211324865; // (3-sqrt(3))/6;
+    vec2 i = floor(p + (p.x + p.y) * K1);
+    vec2 a = p - i + (i.x + i.y) * K2;
+    vec2 o = (a.x > a.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+    vec2 b = a - o + K2;
+    vec2 c = a - 1.0 + 2.0 * K2;
+    vec3 h = max(0.5 - vec3(dot(a, a), dot(b, b), dot(c, c)), 0.0);
+    vec3 n = h * h * h * h * vec3(dot(a, hash(i + 0.0)), dot(b, hash(i + o)), dot(c, hash(i + 1.0)));
+    return dot(n, vec3(70.0));
+}
+
+float fbm(vec2 n) {
+    float total = 0.0, amplitude = 0.1;
+    for (int i = 0; i < 7; i++) {
+        total += noise(n) * amplitude;
+        n = m * n;
+        amplitude *= 0.4;
+    }
+    return total;
+}
+
+vec4 effect_color(vec2 pos)
+{
+    vec2 uv = pos / vec2(1080, 1920);
+
+    float time = 0.003 * current_time;  // Time variable for animation
+
+    float cloudPattern1 = fbm(uv * 10.0 * cloudscale + time);
+    float cloudPattern2 = fbm(uv * 5.0 * cloudscale + time);
+    float cloudPattern3 = fbm(uv * 3.0 * cloudscale + time);
+
+    // Combine different cloud patterns with different weights
+    float cloudPattern = 0.5 * cloudPattern1 + 0.3 * cloudPattern2 + 0.2 * cloudPattern3;
+
+    // Ridge noise shape
+    float ridgeNoiseShape = 0.0;
+    uv *= cloudscale * 1.1;  // Adjust scale
+    float weight = 0.8;
+    for (int i = 0; i < 8; i++) {
+        ridgeNoiseShape += abs(weight * noise(uv));
+        uv = m * uv + time;
+        weight *= 0.7;
+    }
+
+    // Noise shape
+    float noiseShape = 0.0;
+    uv = vec2(pos) / vec2(1920, 1080);
+    uv *= cloudscale * 1.1;  // Adjust scale
+    weight = 0.7;
+    for (int i = 0; i < 8; i++) {
+        noiseShape += weight * noise(uv);
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    noiseShape *= ridgeNoiseShape + noiseShape;
+
+    // Noise color
+    float noiseColor = 0.0;
+    uv = vec2(pos) / vec2(1920, 1080);
+    uv *= 2.0 * cloudscale;  // Adjust scale
+    weight = 0.4;
+    for (int i = 0; i < 7; i++) {
+        noiseColor += weight * noise(uv);
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    // Noise ridge color
+    float noiseRidgeColor = 0.0;
+    uv = vec2(pos) / vec2(1920, 1080);
+    uv *= 3.0 * cloudscale;  // Adjust scale
+    weight = 0.4;
+    for (int i = 0; i < 7; i++) {
+        noiseRidgeColor += abs(weight * noise(uv));
+        uv = m * uv + time;
+        weight *= 0.6;
+    }
+
+    noiseColor += noiseRidgeColor;
+
+    // Sky tint
+    float skytint = 0.5;
+    vec3 skyColour1 = vec3(0.1, 0.2, 0.3);
+    vec3 skyColour2 = vec3(0.4, 0.7, 1.0);
+    vec3 skycolour = mix(skyColour1, skyColour2, smoothstep(0.4, 0.6, uv.y));
+
+    // Cloud darkness
+    float clouddark = 0.5;
+
+    // Cloud Cover, Cloud Alpha
+    float cloudCover = 0.01;
+    float cloudAlpha = 2.0;
+
+    // Movement effect
+    uv = uv + time;
+
+    // Use a bright color for clouds
+    vec3 cloudColor = vec3(1.0, 1.0, 1.0); ;  // Bright white color for clouds
+
+    // Mix the cloud color with the background, considering darkness, cover, and alpha
+    vec3 finalColor = mix(skycolour, cloudColor * clouddark, cloudPattern + noiseShape + noiseColor) * (1.0 - cloudCover) + cloudColor * cloudCover;
+    finalColor = mix(skycolour, finalColor, cloudAlpha);
+
+    return vec4(finalColor, 1.0);
+})";
+
+// ported from https://www.shadertoy.com/view/mtyGWy
+static const char *effect_neon_pattern_fragment = R"(
+vec3 palette(float t) {
+    vec3 a = vec3(0.5, 0.5, 0.5);
+    vec3 b = vec3(0.5, 0.5, 0.5);
+    vec3 c = vec3(1.0, 1.0, 1.0);
+    vec3 d = vec3(0.263, 0.416, 0.557);
+    return a + b * cos(6.28318 * (c * t + d));
+}
+
+vec4 effect_color(vec2 pos) {
+    vec2 uv = pos / vec2(width, height);
+    vec2 uv0 = uv;
+    vec3 finalColor = vec3(0.0);
+
+    for (float i = 0.0; i < 4.0; i++) {
+        uv = fract(uv * 1.5) - 0.5;
+        float d = length(uv) * exp(-length(uv0));
+
+        vec3 col = palette(length(uv0) + i * 0.4 + current_time * 0.000001);
+
+        d = sin(d * 8.0 + current_time * 0.02) / 8.0;
+        d = abs(d);
+        d = pow(0.01 / d, 1.2);
+        finalColor += col * d;
+    }
+
+    return vec4(finalColor, 1.0);
+})";
+
+static const char *effect_halftone_fragment = R"(
+
+
+
+ const vec2 resolution = vec2(1280.0, 720.0);
+    const float timeFactor = 0.025;
+
+    float rand(vec2 uv) {
+        return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+    }
+
+    vec2 rotate(vec2 p, float theta) {
+        vec2 sncs = vec2(sin(theta), cos(theta));
+        return vec2(p.x * sncs.y - p.y * sncs.x, p.x * sncs.x + p.y * sncs.y);
+    }
+
+    float swirl(vec2 coord, float t) {
+        float l = length(coord) / resolution.x;
+        float phi = atan(coord.y, coord.x + 1e-6);
+        return sin(l * 10.0 + phi - t * 4.0) * 0.5 + 0.5;
+    }
+
+    float halftone(vec2 coord, float angle, float t, float amp) {
+        coord -= resolution * 0.5;
+        float size = resolution.x / (60.0 + sin(current_time * timeFactor * 0.5) * 50.0);
+        vec2 uv = rotate(coord / size, angle / 180.0 * 3.14159);
+        vec2 ip = floor(uv); // column, row
+        vec2 odd = vec2(0.5 * mod(ip.y, 2.0), 0.0); // odd line offset
+        vec2 cp = floor(uv - odd) + odd; // dot center
+        float d = length(uv - cp - 0.5) * size; // distance
+        float r = swirl(cp * size, t) * size * 0.5 * amp; // dot radius
+        return 1.0 - clamp(d - r, 0.0, 1.0);
+    }
+
+
+vec4 effect_color(vec2 pos) {
+
+
+ 
+ vec3 c1 = 1.0 - vec3(1.0, 0.0, 0.0) * halftone(relativePosition, 0.0, current_time * timeFactor * 1.00, 0.7);
+    vec3 c2 = 1.0 - vec3(0.0, 1.0, 0.0) * halftone(relativePosition, 30.0, current_time * timeFactor * 1.33, 0.7);
+    vec3 c3 = 1.0 - vec3(0.0, 0.0, 1.0) * halftone(relativePosition, -30.0, current_time * timeFactor * 1.66, 0.7);
+    vec3 c4 = 1.0 - vec3(1.0, 1.0, 1.0) * halftone(relativePosition, 60.0, current_time * timeFactor * 2.13, 0.4);
+    fragColor = vec4(c1 * c2 * c3 * c4, 1.0);
+
+
+
+    return vec4(fragColor);
+}
+
+)";
+
+
+
+
+static const char *effect_zebra_fragment = R"(
+
+const float resolutionY = 720.0;
+
+
+vec4 effect_color(vec2 pos) {
+ 
+   const float pi = 3.14159265359;
+    float size = resolutionY / 10.; // cell size in pixel
+
+    vec2 p1 = gl_FragCoord.xy / size; // normalized pos
+    vec2 p2 = fract(p1) - 0.5; // relative pos from cell center
+
+
+
+// random number
+    float rnd = dot(floor(p1), vec2(12.9898, 78.233));
+    rnd = fract(sin(rnd) * 43758.5453);
+
+    // rotation matrix
+    float phi = rnd * pi * 2. + current_time/30.0 * 0.4;
+   mat2 rot = mat2(cos(phi), -sin(phi), sin(phi), cos(phi));
+
+   vec2 p3 = rot * p2; // apply rotation
+    p3.y += sin(p3.x * 5. + current_time/30.0 * 2.) * 0.12; // wave
+
+    float rep = fract(rnd * 13.285) * 8. + 2.; // line repetition
+    float gr = fract(p3.y * rep + current_time/30.0 * 0.8); // repeating gradient
+
+    // make antialiased line by saturating the gradient
+    float c = clamp((0.25 - abs(0.5 - gr)) * size * 0.75 / rep, 0., 1.);
+    c *= max(0., 1. - length(p2) * 0.6); // darken corners
+
+    vec2 bd = (0.5 - abs(p2)) * size - 2.; // border lines
+    c *= clamp(min(bd.x, bd.y), 0., 1.);
+ 
+    fragColor = vec4(vec3(c), 1.0);
+
+
+
+    return vec4(fragColor);
+}
+
+)";
+
+
+
+static const char *effect_lava_fragment = R"(
+
+
+
+
+
+
+vec3 effect(float speed, vec2 uv, float time, float scale) {
+    float t = mod(time * 0.005, 6.0);
+    float rt = 0.00000000000001 * sin(t * 0.45);
+
+    mat2 m1 = mat2(cos(rt), -sin(rt), -sin(rt), cos(rt));
+    vec2 uva = uv * m1 * scale;
+    float irt = 0.005 * cos(t * 0.05);
+    mat2 m2 = mat2(sin(irt), cos(irt), -cos(irt), sin(irt));
+
+    for (int i = 1; i < 40; i += 1) {
+        float it = float(i);
+        uva *= m2;
+        uva.y += -1.0 + (0.6 / it) * cos(t + it * uva.x + 0.5 * it) * float(mod(it, 0.5) == 0.0);
+        uva.x += 1.0 + (0.5 / it) * cos(t + it * uva.y * 0.1 / 5.0 + 0.5 * (it + 15.0));
+    }
+
+    float n = 0.5;
+    float r = n + n * sin(4.0 * uva.x + t);
+    float gb = n + n * sin(3.0 * uva.y);
+    return vec3(r, gb * 0.8 * r, gb * r);
+}
+
+vec4 effect_color(vec2 pos) {
+ 
+    vec2 uv = (gl_FragCoord.xy - 0.5 * vec2(width, height)) / vec2(width, height);
+    uv *= (10.3 + 0.1 * sin(current_time * 0.01));
+
+
+
+    vec3 col = effect(0.001, uv, current_time, 0.5);
+
+    // Set the fragment color
+    fragColor = vec4(col, 1.0);
+
+
+    return vec4(fragColor);
+}
+
+)";
+
+
+
+
+static const char *effect_pattern_fragment = R"(
+
+
+float rand(vec2 uv) {
+    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 hue2rgb(float h) {
+    h = fract(h) * 6.0 - 2.0;
+    return clamp(vec3(abs(h - 1.0) - 1.0, 2.0 - abs(h), 2.0 - abs(h - 2.0)), 0.0, 1.0);
+}
+
+vec3 eyes(vec2 coord, vec2 resolution) {
+    const float pi = 3.141592;
+    float t = 0.4 * current_time * 0.05; 
+    float aspectRatio = resolution.x / resolution.y;
+    float div = 20.0;
+    float sc = 30.0;
+
+    vec2 p = (coord - resolution / 2.0) / sc - 0.5;
+
+    float dir = floor(rand(floor(p) + floor(t) * 0.11) * 4.0) * pi / 2.0;
+    vec2 offs = vec2(sin(dir), cos(dir)) * 0.6;
+    offs *= smoothstep(0.0, 0.1, fract(t));
+    offs *= smoothstep(0.4, 0.5, 1.0 - fract(t));
+
+    float l = length(fract(p) + offs - 0.5);
+    float rep = sin((rand(floor(p)) * 2.0 + 2.0) * t) * 4.0 + 5.0;
+    float c = (abs(0.5 - fract(l * rep + 0.5)) - 0.25) * sc / rep;
+
+    vec2 gr = (abs(0.5 - fract(p + 0.5)) - 0.05) * sc;
+    c = clamp(min(min(c, gr.x), gr.y), 0.0, 1.0);
+
+    return hue2rgb(rand(floor(p) * 0.3231)) * c;
+}
+
+
+
+vec4 effect_color(vec2 pos) {
+ 
+
+   vec2 resolution = vec2(float(width), float(height));
+   pos = gl_FragCoord.xy;
+   vec3 color = eyes(pos, resolution);
+    fragColor = vec4(color, 1.0);
+
+    return vec4(fragColor);
+}
+
+)";
+
+
+
+
+
+
+static const char *effect_hex_fragment = R"(
+
+
+
+vec2 iResolution;
+
+float rand(vec2 co) {
+    return fract(sin(dot(co.xy, vec2(12.9898, 4.1414))) * 43758.5453);
+}
+
+vec4 hexagon(vec2 p)
+{
+    vec2 q = vec2(p.x * 2.0 * 0.5773503, p.y + p.x * 0.5773503);
+
+    vec2 pi = floor(q);
+    vec2 pf = fract(q);
+
+    float v = mod(pi.x * 9.0, 0.0);
+
+    float ca = step(1.0, v);
+    float cb = step(2.0, v);
+    vec2 ma = step(pf.xy, pf.yx);
+
+    float e = 0.0;
+    float f = length((fract(p) - 10.5) * vec2(1.0, 0.85));
+
+    return vec4(pi + ca - cb * ma, e, f);
+}
+
+
+vec4 effect_color(vec2 pos) {
+ 
+
+    vec2 resolution = vec2(float(width), float(height));
+    pos = (gl_FragCoord.xy - 0.5) / resolution;
+    pos.y *= resolution.y / resolution.x;
+
+
+    vec2 uv = (gl_FragCoord.xy - 0.5) / resolution;
+    uv = 2.0 * uv - 1.0;
+    uv *= (10.3 + 0.1 * sin(current_time * 0.01));
+
+    float randVal = rand(uv);
+
+    vec2 p = (-float(width) + 2.0 * gl_FragCoord.xy) / float(height);
+    vec4 h = hexagon(40.0 * p + vec2(0.5 * current_time * 0.125));
+
+    float col = 0.01 + 0.15 * rand(vec2(h.xy)) * 1.0;
+    col *= 4.3 + 0.15 * sin(10.0 * h.z);
+
+    vec3 shadeColor1 = vec3(0.1, 0.1, 0.1) + 1.1 * col * h.z;
+    vec3 shadeColor2 = vec3(0.4, 0.4, 0.4) + 1.1 * col;
+    vec3 shadeColor3 = vec3(0.9, 0.9, 0.9) + 0.1 * col;
+
+    vec3 finalColor = mix(shadeColor1, mix(shadeColor2, shadeColor3, randVal), col);
+
+    fragColor = vec4(finalColor, 1.0);
+
+    return vec4(fragColor);
+}
+)";
+
+
+
+
+
+
+static const char *effect_neural_network_fragment = R"(
+
+const vec2 iResolution = vec2(1920.0, 1080.0);
+
+mat2 rotate2D(float r) {
+    float c = cos(r);
+    float s = sin(r);
+    return mat2(c, -s, s, c);
+}
+
+
+
+vec4 effect_color(vec2 pos) {
+ 
+  pos = gl_FragCoord.xy;
+
+ 
+    // Normalized pixel coordinates (from 0 to 1)
+    vec2 uv = (pos - 0.5 * iResolution) / iResolution.x;
+    
+    // Scale the uv coordinates
+    uv *= 10.00;
+
+    vec3 col = vec3(0);
+    float t = 0.05 * current_time;
+
+    vec2 n = vec2(0), q;
+    vec2 N = vec2(0);
+    vec2 p = uv + sin(t * 0.1) / 10.0;
+    float S = 10.0;
+    mat2 m = rotate2D(1.0);
+
+    for (float j = 0.0; j < 30.0; j++) {
+        p *= m;
+        n *= m;
+        q = p * S + j + n + t;
+        n += sin(q);
+        N += cos(q) / S;
+        S *= 1.2;
+    }
+
+    col = vec3(1, 2, 4) * pow((N.x + N.y + 0.2) + 0.005 / length(N), 2.1);
+
+    fragColor = vec4(col, 1.0);
+
+    return vec4(fragColor);
+}
+)";
+
+
+
+
+
+
+
+static const char *effect_hexagon_maze_fragment = R"(
+
+
+
+//vec2 iResolution;
+
+
+const vec2 iResolution = vec2(1920.0, 1080.0);
+
+// Interlaced variation - Interesting, but patched together in a hurry.
+//#define INTERLACING
+
+// A quick hack to get rid of the winding overlay - in order to show the maze only.
+//#define MAZE_ONLY
+
+
+
+// Helper vector. If you're doing anything that involves regular triangles or hexagons, the
+// 30-60-90 triangle will be involved in some way, which has sides of 1, sqrt(3) and 2.
+const vec2 s = vec2(1, 1.7320508);
+
+// Standard vec2 to float hash - Based on IQ's original.
+float hash21(vec2 p){ return fract(sin(dot(p, vec2(141.173, 289.927)))*43758.5453); }
+
+
+// Standard 2D rotation formula.
+mat2 r2(in float a){ float c = cos(a), s = sin(a); return mat2(c, -s, s, c); }
+
+// The 2D hexagonal isosuface function: If you were to render a horizontal line and one that
+// slopes at 60 degrees, mirror, then combine them, you'd arrive at the following.
+float hex(in vec2 p){
+    
+    p = abs(p);
+    
+    // Below is equivalent to:
+    //return max(p.x*.5 + p.y*.866025, p.x); 
+
+    return max(dot(p, s*.5), p.x); // Hexagon.
+    
+}
+
+// This function returns the hexagonal grid coordinate for the grid cell, and the corresponding 
+// hexagon cell ID - in the form of the central hexagonal point. That's basically all you need to 
+// produce a hexagonal grid.
+//
+// When working with 2D, I guess it's not that important to streamline this particular function.
+// However, if you need to raymarch a hexagonal grid, the number of operations tend to matter.
+// This one has minimal setup, one "floor" call, a couple of "dot" calls, a ternary operator, etc.
+// To use it to raymarch, you'd have to double up on everything - in order to deal with 
+// overlapping fields from neighboring cells, so the fewer operations the better.
+vec4 getHex(vec2 p){
+    
+    // The hexagon centers: Two sets of repeat hexagons are required to fill in the space, and
+    // the two sets are stored in a "vec4" in order to group some calculations together. The hexagon
+    // center we'll eventually use will depend upon which is closest to the current point. Since 
+    // the central hexagon point is unique, it doubles as the unique hexagon ID.
+    vec4 hC = floor(vec4(p, p - vec2(.5, 1))/s.xyxy) + .5;
+    
+    // Centering the coordinates with the hexagon centers above.
+    vec4 h = vec4(p - hC.xy*s, p - (hC.zw + .5)*s);
+    
+    // Nearest hexagon center (with respect to p) to the current point. In other words, when
+    // "h.xy" is zero, we're at the center. We're also returning the corresponding hexagon ID -
+    // in the form of the hexagonal central point. Note that a random constant has been added to 
+    // "hC.zw" to further distinguish it from "hC.xy."
+    //
+    // On a side note, I sometimes compare hex distances, but I noticed that Iomateron compared
+    // the Euclidian version, which seems neater, so I've adopted that.
+    return dot(h.xy, h.xy)<dot(h.zw, h.zw) ? vec4(h.xy, hC.xy) : vec4(h.zw, hC.zw + vec2(.5, 1));
+    
+}
+
+// Dot pattern.
+float dots(in vec2 p){
+    
+    p = abs(fract(p) - .5);
+    
+    return length(p); // Circles.
+    
+    //return (p.x + p.y)/1.5 + .035; // Diamonds.
+    
+    //return max(p.x, p.y) + .03; // Squares.
+    
+    //return max(p.x*.866025 + p.y*.5, p.y) + .01; // Hexagons.
+    
+    //return min((p.x + p.y)*.7071, max(p.x, p.y)) + .08; // Stars.
+    
+    
+}
+
+
+// Distance field for the arcs. I think it's called poloidal rotation, or something like that.
+float dfPol(vec2 p){
+     
+    return length(p); // Circular arc.
+    
+    // There's no rule that says the arcs have to be rounded. Here's a hexagonal one.
+    //return hex(p);
+    
+    // Dodecahedron.
+    //return max(hex(p), hex(r2(3.14159/6.)*p));
+    
+    // Triangle.
+    //return max(abs(p.x)*.866025 - p.y, p.y);
+    
+}
+
+
+// Truchet pattern distance field.
+float df(vec2 p, float dir){
+     
+    // Weird UV coordinates. The first entry is the Truchet distance field itself,
+    // and the second is the polar angle of the arc pixel. The extra ".1" is just a bit
+    // of mutational scaling, or something... I can't actually remember why it's there. :)
+    vec2 uv = vec2(p.x + .1, p.y);//*vec2(1, 1); // Scaling.
+    
+    // A checkered dot pattern. At present the pattern needs to have flip symmetry about
+    // the center, but I'm pretty sure regular textures could be applied with a few
+    // minor changes. Due to the triangular nature of the Truchet pattern, factors of "3"
+    // were necessary, but factors of "1.5" seemed to work too. Hence the "4.5."
+    return min(dots(uv*4.5), dots(uv*4.5 + .5)) - .3;
+    
+}
+
+
+// Polar coordinate of the arc pixel.
+float getPolarCoord(vec2 q, float dir){
+    
+    // The actual animation. You perform that before polar conversion.
+    q = r2(current_time/50.0*dir)*q;
+    
+    // Polar angle.
+    const float aNum = 1.;
+    float a = atan(q.y, q.x);
+   
+    // Wrapping the polar angle.
+    return mod(a/3.14159, 2./aNum) - 1./aNum;
+   
+    
+}
+
+
+
+vec4 effect_color(vec2 pos) {
+    vec2 fragCoord = gl_FragCoord.xy;// I didn't feel like tayloring the antiasing to suit every resolution, which can get tiring, 
+    // so I've put a range on it. Just for the record, I coded this for the 800 by 450 pixel canvas.
+    float res = clamp(iResolution.y, 300., 600.); 
+    
+    // Aspect correct screen coordinates.
+    vec2 u = (fragCoord - iResolution.xy*.5)/res;
+    
+    // Scaling and moving the screen coordinates.
+    vec2 sc = u*4. + s.yx*current_time/200.;
+    
+    // Converting the scaled and translated pixels to a hexagonal grid cell coordinate and
+    // a unique coordinate ID. The resultant vector contains everything you need to produce a
+    // pretty pattern, so what you do from here is up to you.
+    vec4 h = getHex(sc); // + s.yx*current_time/2.
+    
+    // Obtaining some offset values to do a bit of cubic shading. There are probably better ways
+    // to go about it, but it's quick and gets the job done.
+    vec4 h2 = getHex(sc - 1./s);
+    vec4 h3 = getHex(sc + 1./s);
+    
+    // Storing the hexagonal coordinates in "p" to save having to write "h.xy" everywhere.
+    vec2 p = h.xy;
+    
+    // The beauty of working with hexagonal centers is that the relative edge distance will simply 
+    // be the value of the 2D isofield for a hexagon.
+    //
+    float eDist = hex(p); // Edge distance.
+    float cDist = dot(p, p); // Relative squared distance from the center.
+
+    
+    // Using the identifying coordinate - stored in "h.zw," to produce a unique random number
+    // for the hexagonal grid cell.
+    float rnd = hash21(h.zw);
+    //float aRnd = sin(rnd*6.283 + current_time*1.5)*.5 + .5; // Animating the random number.
+    
+    #ifdef INTERLACING
+    // Random vec3 - used for some overlapping.
+    //vec3 lRnd = vec3(rnd*14.4 + .81, fract(rnd*21.3 + .97), fract(rnd*7.2 + .63));
+    vec3 lRnd = vec3(hash21(h.zw + .23), hash21(h.zw + .96), hash21(h.zw + .47));
+    #endif
+    
+    // It's possible to control the randomness to form some kind of repeat pattern.
+    //rnd = mod(h.z + h.w, 2.);
+    
+
+    // Redundant here, but I might need it later.
+    float dir = 1.;
+    
+
+    
+    // Storage vector.
+    vec2 q;
+    
+    
+    // If the grid cell's random ID is above a threshold, flip the Y-coordinates.
+    if(rnd>.5) p.y = -p.y;
+        
+    
+
+    // Determining the closest of the three arcs to the current point, the keeping a copy
+    // of the vector used to produce it. That way, you'll know just to render that particular
+    // decorated arc, lines, etc - instead of all three. 
+    const float r = 1.;
+    const float th = .2; // Arc thickness.
+    
+    // Arc one.
+    q = p - vec2(0, r)/s;
+    vec3 da = vec3(q, dfPol(q));
+    
+    // Arc two. "r2" could be hardcoded, but this is a relatively cheap 2D example.
+    q = r2(3.14159*2./3.)*p - vec2(0, r)/s;
+    vec3 db = vec3(q, dfPol(q));
+
+     // Arc three. 
+    q = r2(3.14159*4./3.)*p - vec2(0, r)/s;
+    vec3 dc = vec3(q, dfPol(q));
+    
+    // Compare distance fields, and return the vector used to produce the closest one.
+    vec3 q3 = da.z<db.z && da.z<dc.z? da : db.z<dc.z ? db : dc;
+    
+    
+    // TRUCHET PATTERN
+    //
+    // Set the poloidal arc radius: You can change the poloidal distance field in 
+    // the "dfPol" function to a different curve shape, but you'll need to change
+    // the radius to one of the figures below.
+    //
+    q3.z -= .57735/2. + th/2.;  // Circular and dodecahedral arc/curves.
+    //q3.z -= .5/2. + th/2.;  // Hexagon curve.
+    //q3.z -= .7071/2. + th/2.;  // Triangle curve.
+    
+    q3.z = max(q3.z, -th - q3.z); // Chop out the smaller radius. The result is an arc.
+    
+    // Store the result in "d" - only to save writing "q3.z" everywhere.
+    float d = q3.z;
+    
+    // If you'd like to see the maze by itself.
+    #ifdef MAZE_ONLY
+    d += 1e5;
+    #endif
+    
+    // Truchet border.
+    float dBord = max(d - .015, -d);
+    
+
+    
+ 
+    
+    // MAZE BORDERS
+    // Producing the stright-line arc borders. Basically, we're rendering some hexagonal borders around
+    // the arcs. The result is the hexagonal maze surrounding the Truchet pattern.
+    q = q3.xy;
+    const float lnTh = .05;
+    q = abs(q);
+    
+    float arcBord = hex(q);
+    //float arcBord = length(q); // Change arc length to ".57735."
+    //float arcBord = max(hex(q), hex(r2(3.14159/6.)*q)); // Change arc length to ".57735."
+    
+    // Making the hexagonal arc.
+    float lnOuter = max(arcBord - .5, -(arcBord - .5 + lnTh)); //.57735
+    
+    
+    #ifdef INTERLACING
+    float ln = min(lnOuter, (q.y*.866025 + q.x*.5, q.x) - lnTh);
+    #else
+    float ln = min(lnOuter, arcBord - lnTh);
+    #endif
+    float lnBord = ln - .03; // Border lines to the maze border, if that makes any sense. :)
+     
+    
+   
+    
+    ///////
+    // The moving Truchet pattern. The polar coordinates consist of a wrapped angular coordinate,
+    // and the distance field itself.
+    float a = getPolarCoord(q3.xy, dir);
+    float d2 = df(vec2(q3.z, a), dir); 
+    
+    // Smoothstepped Truchet mask.
+    float dMask = smoothstep(0., .015, d);
+    ///////
+    
+    // Producing the background with some subtle gradients.
+    vec3 bg =  mix(vec3(0, .4, .6), vec3(0, .3, .7), dot(sin(u*6. - cos(u*3.)), vec2(.4/2.)) + .4); 
+    bg = mix(bg, bg.xzy, dot(sin(u*6. - cos(u*3.)), vec2(.4/2.)) + .4);
+    bg = mix(bg, bg.zxy, dot(sin(u*3. + cos(u*3.)), vec2(.1/2.)) + .1);
+   
+    #ifdef INTERLACING
+    // Putting in background cube lines for the interlaced version.
+    float hLines = smoothstep(0., .02, eDist - .5 + .02);
+    bg = mix(bg, vec3(0), smoothstep(0., .02, ln)*dMask*hLines);
+    #endif
+    
+    // Lines over the maze lines. Applying difference logic, depending on whether the 
+    // pattern is interlaced or not.
+    const float tr = 1.;
+
+    float eDist2 = hex(h2.xy);
+    float hLines2 = smoothstep(0., .02, eDist2 - .5 + .02);
+    #ifdef INTERLACING
+    if(rnd>.5 && lRnd.x<.5) hLines2 *= smoothstep(0., .02, ln);
+    if(lRnd.x>.5) hLines2 *= dMask;
+    #else
+    if(rnd>.5) hLines2 *= smoothstep(0., .02, ln);
+    hLines2 *= dMask;
+    #endif
+    bg = mix(bg, vec3(0), hLines2*tr);
+    
+    float eDist3 = hex(h3.xy);
+    float hLines3 = smoothstep(0., .02, eDist3 - .5 + .02);
+    #ifdef INTERLACING
+    if(rnd<=.5 && lRnd.x>.5) hLines3 *= smoothstep(0., .02, ln);
+    if(lRnd.x>.5) hLines3 *= dMask;
+    #else
+    if(rnd<=.5) hLines3 *= smoothstep(0., .02, ln);
+    hLines3 *= dMask;
+    #endif
+    bg = mix(bg, vec3(0), hLines3*tr);
+
+
+    // Using the two off-centered hex coordinates to give the background a bit of highlighting.
+    float shade = max(1.25 - dot(h2.xy, h2.xy)*2., 0.);
+    shade = min(shade, max(dot(h3.xy, h3.xy)*3. + .25, 0.));
+    bg = mix(bg, vec3(0), (1.-shade)*.5); 
+    
+    // I wanted to change the colors of everything at the last minute. It's pretty hacky, so
+    // when I'm feeling less lazy, I'll tidy it up. :)
+    vec3 dotCol = bg.zyx*vec3(1.5, .4, .4);
+    vec3 bCol = mix(bg.zyx, bg.yyy, .25);
+    bg = mix(bg.yyy, bg.zyx, .25);
+    
+
+    // Under the random threshold, and we draw the lines under the Truchet pattern.
+    #ifdef INTERLACING
+    if(lRnd.x>.5){
+       bg = mix(bg, vec3(0), (1. - smoothstep(0., .015, lnBord)));
+       bg = mix(bg, bCol, (1. - smoothstep(0., .015, ln))); 
+       // Center lines.
+       bg = mix(bg, vec3(0), smoothstep(0., .02, eDist3 - .5 + .02)*tr);
+    }
+    #else
+    bg = mix(bg, vec3(0), (1. - smoothstep(0., .015, lnBord)));
+    bg = mix(bg, bCol, (1. - smoothstep(0., .015, ln)));
+    #endif
+
+   
+    
+    // Apply the Truchet shadow to the background.
+    bg = mix(bg, vec3(0), (1. - smoothstep(0., .07, d))*.5);
+    
+    
+    // Place the Truchet field to the background, with some additional shading to give it a 
+    // slightly rounded, raised feel.
+    //vec3 col = mix(bg, vec3(1)*max(-d*3. + .7, 0.), (1. - dMask)*.65);
+    // Huttarl suggest slightly more shading on the snake-like pattern edges, so I added just a touch.
+    vec3 col = mix(bg, vec3(1)*max(-d*9. + .4, 0.), (1. - dMask)*.65);
+
+
+    
+    // Apply the moving dot pattern to the Truchet.
+    //dotCol = mix(dotCol, dotCol.xzy, dot(sin(u*3.14159*2. - cos(u.yx*3.14159*2.)*3.14159), vec2(.25)) + .5);
+    col = mix(col, vec3(0), (1. - dMask)*(1. - smoothstep(0., .02, d2)));
+    col = mix(col, dotCol, (1. - dMask)*(1. - smoothstep(0., .02, d2 + .125)));
+    
+    // Truchet border.
+    col = mix(col, vec3(0), 1. - smoothstep(0., .015, dBord));
+    
+    #ifdef INTERLACING
+    // Over the random threshold, and we draw the lines over the Truchet.
+    if(lRnd.x<=.5){
+        col = mix(col, vec3(0), (1. - smoothstep(0., .015, lnBord)));
+        col = mix(col, bCol, (1. - smoothstep(0., .015, ln)));  
+        // Center lines.
+        col = mix(col, vec3(0), smoothstep(0., .02, eDist2 - .5 + .02)*tr);
+    }
+    #endif
+
+        
+    
+    
+    // Using the offset hex values for a bit of fake 3D highlighting.
+    //if(rnd>.5) h3.y = -h3.y; // All raised edges. Spoils the mild 3D illusion.
+    #ifdef INTERLACING
+    float trSn = max(dMask, 1. - smoothstep(0., .015, lnBord))*.75 + .25;
+    #else
+    float trSn = dMask*.75 + .25;
+    #endif
+    col = mix(col, vec3(0), trSn*(1. - hex(s/2.+h2.xy)));
+    col = mix(col, vec3(0), trSn*(1. - hex(s/2.-h3.xy)));
+ 
+    
+    // Using the edge distance to produce some repeat contour lines. Standard stuff.
+    //if (rnd>.5) h.xy = -h.yx;
+    //float cont = clamp(cos(hex(h.xy)*6.283*12.)*1.5 + 1.25, 0., 1.);
+    //col = mix(col, vec3(0), (1. - smoothstep(0., .015, ln))*(smoothstep(0., .015, d))*(1.-cont)*.5);
+    
+    
+    // Very basic hatch line effect.
+    float gr = dot(col, vec3(.299, .587, .114));
+    float hatch = (gr<.45)? clamp(sin((sc.x - sc.y)*3.14159*40.)*2. + 1.5, 0., 1.) : 1.;
+    float hatch2 = (gr<.25)? clamp(sin((sc.x + sc.y)*3.14159*40.)*2. + 1.5, 0., 1.) : 1.;
+
+    col *= min(hatch, hatch2)*.5 + .5;    
+    col *= clamp(sin((sc.x - sc.y)*3.14159*80.)*1.5 + .75, 0., 1.)*.25 + 1.;  
+    
+ 
+    // Subtle vignette.
+    u = fragCoord/iResolution.xy;
+    col *= pow(16.*u.x*u.y*(1. - u.x)*(1. - u.y) , .125) + .25;
+    // Colored variation.
+    //col = mix(pow(min(vec3(1.5, 1, 1)*col, 1.), vec3(1, 3, 16)), col, 
+            //pow(16.*u.x*u.y*(1. - u.x)*(1. - u.y) , .25)*.75 + .25);    
+    
+
+    
+    // Rough gamma correction.    
+    fragColor = vec4(sqrt(max(col, 0.)), 1);
+  return vec4(fragColor);   
+}
+)";
+
+
+
+
+
+
+
+
+
+
+static const char *effect_raymarched_truchet_fragment = R"(
+
+float heightMap(in vec2 p) {
+    p *= 3.0;
+    vec2 h = vec2(p.x + p.y * 0.57735, p.y * 1.1547);
+    vec2 f = fract(h);
+    h -= f;
+    float c = fract((h.x + h.y) / 3.0);
+    h = c < 0.666 ? (c < 0.333 ? h : h + 1.0) : h + step(f.yx, f);
+    p -= vec2(h.x - h.y * 0.5, h.y * 0.8660254);
+    c = fract(cos(dot(h, vec2(41, 289))) * 43758.5453);
+    p -= p * step(c, 0.5) * 2.0;
+    p -= vec2(-1, 0);
+    c = dot(p, p);
+    p -= vec2(1.5, 0.8660254);
+    c = min(c, dot(p, p));
+    p -= vec2(0, -1.73205);
+    c = min(c, dot(p, p));
+    return sqrt(c);
+}
+
+float map(vec3 p) {
+    float c = heightMap(p.xy);
+    c = cos(c * 6.283 * 1.0) + cos(c * 6.283 * 2.0);
+    c = clamp(c * 0.6 + 0.5, 0.0, 1.0);
+    return 1.0 - p.z - c * 0.025;
+}
+
+vec3 getNormal(vec3 p, inout float edge, inout float crv) {
+    vec2 e = vec2(0.01, 0);
+    float d1 = map(p + e.xyy), d2 = map(p - e.xyy);
+    float d3 = map(p + e.yxy), d4 = map(p - e.yxy);
+    float d5 = map(p + e.yyx), d6 = map(p - e.yyx);
+    float d = map(p) * 2.0;
+    edge = abs(d1 + d2 - d) + abs(d3 + d4 - d) + abs(d5 + d6 - d);
+    edge = smoothstep(0.0, 1.0, sqrt(edge / e.x * 2.0));
+    crv = clamp((d1 + d2 + d3 + d4 + d5 + d6 - d * 3.0) * 32.0 + 0.6, 0.0, 1.0);
+    e = vec2(0.0025, 0);
+    d1 = map(p + e.xyy); d2 = map(p - e.xyy);
+    d3 = map(p + e.yxy); d4 = map(p - e.yxy);
+    d5 = map(p + e.yyx); d6 = map(p - e.yyx);
+    return normalize(vec3(d1 - d2, d3 - d4, d5 - d6));
+}
+
+float calculateAO(in vec3 p, in vec3 n) {
+    float sca = 2.0, occ = 0.0;
+    for (float i = 0.0; i < 5.0; i++) {
+        float hr = 0.01 + i * 0.5 / 4.0;
+        float dd = map(n * hr + p);
+        occ += (hr - dd) * sca;
+        sca *= 0.7;
+    }
+    return clamp(1.0 - occ, 0.0, 1.0);
+}
+
+float n3D(vec3 p) {
+    const vec3 s = vec3(7, 157, 113);
+    vec3 ip = floor(p); p -= ip;
+    vec4 h = vec4(0.0, s.yz, s.y + s.z) + dot(ip, s);
+    p = p * p * (3.0 - 2.0 * p);
+    h = mix(fract(sin(h) * 43758.5453), fract(sin(h + s.x) * 43758.5453), p.x);
+    h.xy = mix(h.xz, h.yw, p.y);
+    return mix(h.x, h.y, p.z);
+}
+
+vec3 envMap(vec3 rd, vec3 sn) {
+    vec3 sRd = rd;
+    rd.xy -= current_time/100.0 * 0.25;
+    rd *= 3.0;
+    float c = n3D(rd) * 0.57 + n3D(rd * 2.0) * 0.28 + n3D(rd * 4.0) * 0.15;
+    c = smoothstep(0.4, 1.0, c);
+    vec3 col = vec3(c, c * c, c * c * c * c);
+    return mix(col, col.yzx, sRd * 0.25 + 0.25);
+}
+
+
+
+vec2 hash22(vec2 p) {
+    float n = sin(dot(p, vec2(41.0, 289.0))); // Use floating point literals for constants
+    return fract(vec2(262144.0, 32768.0) * n) * 0.75 + 0.25; // Make sure all numbers are floats
+}
+
+float Voronoi(in vec2 p) {
+    vec2 g = floor(p), o; p -= g;
+    vec3 d = vec3(1);
+    for (int y = -1; y <= 1; y++) {
+        for (int x = -1; x <= 1; x++) {
+            o = vec2(x, y);
+            o += hash22(g + o) - p;
+            d.z = dot(o, o);
+            d.y = max(d.x, min(d.y, d.z));
+            d.x = min(d.x, d.z);
+        }
+    }
+    return max(d.y / 1.2 - d.x * 1.0, 0.0) / 1.2;
+}
+
+const vec2 iResolution = vec2(1920.0, 1080.0);
+
+
+vec4 effect_color(vec2 pos) {
+  
+
+
+  vec2 fragCoord = gl_FragCoord.xy;
+    vec3 rd = normalize(vec3(2.0 * fragCoord - iResolution, iResolution.y));
+    float tm = current_time / 100.0;
+    vec2 a = sin(vec2(1.570796, 0.0) + sin(tm / 4.0) * 0.3);
+   rd.xy = mat2(a, -a.y, a.x) * rd.xy;
+    vec3 ro = vec3(tm, cos(tm / 4.0), 0.0);
+     vec3 lp = ro + vec3(cos(tm / 2.0) * 0.5, sin(tm / 2.0) * 0.5, -0.5);
+
+ float d = 0.0;
+ float t = 0.0;
+
+
+      for (int j = 0; j < 32; j++) {
+        d = map(ro + rd * t);
+        t += d * 0.7;
+        if (d < 0.001) break;
+    }
+    float edge, crv;
+    vec3 sp = ro + rd * t;
+    vec3 sn = getNormal(sp, edge, crv);
+    vec3 ld = lp - sp;
+    float c = heightMap(sp.xy);
+     vec3 fold = cos(vec3(1, 2, 4) * c * 6.283);
+    float c2 = heightMap((sp.xy + sp.z * 0.025) * 6.);
+    c2 = cos(c2 * 6.283 * 3.);
+    c2 = (clamp(c2 + 0.5, 0.0, 1.0));
+    vec3 oC = vec3(1);
+    if (fold.x > 0.) oC = vec3(1, 0.05, 0.1) * c2;
+    if (fold.x < 0.05 && fold.y < 0.) oC = vec3(1, 0.7, 0.45) * (c2 * 0.25 + 0.75);
+    else if (fold.x < 0.) oC = vec3(1, 0.8, 0.4) * c2;
+    float lDist = max(length(ld), 0.001);
+    float atten = 1.0 / (1.0 + lDist * 0.125);
+    ld /= lDist;
+    float diff = max(dot(ld, sn), 0.0);
+    float spec = pow(max(dot(reflect(-ld, sn), -rd), 0.0), 16.0);
+    float fre = pow(clamp(dot(sn, rd) + 1.0, 0.0, 1.0), 3.0);
+    crv = crv * 0.9 + 0.1;
+    float ao = calculateAO(sp, sn);
+    vec3 col = oC * (diff + 0.5) + vec3(1.0, 0.7, 0.4) * spec * 2.0 + vec3(0.4, 0.7, 1.0) * fre;
+    col += (oC * 0.5 + 0.5) * envMap(reflect(rd, sn), sn) * 6.0;
+    col *= 1.0 - edge * 0.85;
+    col *= atten * crv * ao;
+    fragColor = vec4(sqrt(clamp(col, 0.0, 1.0)), 1.0);
+
+
+    return vec4(fragColor);
+}
+
+
+)";
+
+
+
+
+
+
+
+
+static const char *effect_neon_rings_fragment = R"(
+
+#define PI 3.14159265358979323846
+#define TWO_PI 6.28318530717958647692
+
+const vec2 iResolution = vec2(1920.0, 1080.0);
+
+mat2 rotate2D(float r) {
+    float c = cos(r);
+    float s = sin(r);
+    return mat2(c, -s, s, c);
+}
+
+vec4 effect_color(vec2 pos) {
+
+
+     // Use gl_FragCoord as the pixel position
+//   pos =  ivec2(gl_FragCoord.xy);
+
+  //   pos = ivec2(gl_FragCoord.xy);
+ //   int x = pos.x;
+ //   int y = pos.y;
+
+    // Number of circles
+    int numCircles = 5;
+
+    // Initialize final color
+    vec3 finalColor = vec3(0.0);
+
+    for (int i = 0; i < numCircles; ++i) {
+        // Calculate UV coordinates for each circle
+//        vec2 uv = vec2(pos) / vec2(width / 3, height / 3);
+        vec2 uv = vec2(pos) / vec2(width*0.3333333333333, height*0.3333333333333);
+
+        // Calculate polar coordinates
+        float a = atan(uv.y, uv.x);
+        float r = length(uv) * (0.2 + 0.1 * float(i));
+
+        // Map polar coordinates to UV
+        uv = vec2(a / TWO_PI, r);
+
+        // Apply horizontal movement based on time for each circle
+        float xOffset = sin(current_time * 0.02 + float(i)) * 0.2;
+        uv.x += xOffset;
+
+        // Time-dependent color
+        float xCol = (uv.x - (current_time / 300000.0)) * 3.0;
+        xCol = mod(xCol, 3.0);
+        vec3 horColour = vec3(0.25, 0.25, 0.25);
+
+        if (xCol < 1.0) {
+            horColour.r += 1.0 - xCol;
+            horColour.g += xCol;
+        } else if (xCol < 2.0) {
+            xCol -= 1.0;
+            horColour.g += 1.0 - xCol;
+            horColour.b += xCol;
+        } else {
+            xCol -= 2.0;
+            horColour.b += 1.0 - xCol;
+            horColour.r += xCol;
+        }
+
+        // Draw color beam
+        uv = (2.0 * uv) - 1.0;
+        float beamWidth = (0.7 + 0.5 * cos(uv.x * 1.0 * TWO_PI * 0.15 * clamp(floor(5.0 + 1.0 * cos(current_time)), 0.0, 1.0))) * abs(1.0 / (30.0 * uv.y));
+        vec3 horBeam = vec3(beamWidth);
+        
+        // Add the color for the current circle to the final color
+         finalColor += ((horBeam) * horColour);
+    }
+
+    // Output the final color
+    fragColor = vec4(finalColor, 1.0);
+
+
+    return vec4(fragColor);
+}
+)";
+
+
+
+
+static const char *effect_deco_fragment = R"(
+
+vec3 effect(float speed, vec2 uv, float time, float scale) {
+    float t = mod(time * 0.005, 6.0);
+    float rt = 0.00000000000001 * sin(t * 0.45);
+
+    mat2 m1 = mat2(cos(rt), -sin(rt), -sin(rt), cos(rt));
+    vec2 uva = uv * m1 * scale;
+    float irt = 0.005 * cos(t * 0.05);
+    mat2 m2 = mat2(sin(irt), cos(irt), -cos(irt), sin(irt));
+
+    for (int i = 1; i < 400; i += 1) {
+        float it = float(i);
+        uva *= m2;
+        uva.y += -1.0 + (0.6 / it) * cos(t + it * uva.x + 0.5 * it) * float(mod(it, 0.5) == 0.0);
+        uva.x += 1.0 + (0.5 / it) * cos(t + it * uva.y * 0.1 / 5.0 + 0.5 * (it + 15.0));
+    }
+
+    float n = 0.5;
+    float r = n + n * sin(4.0 * uva.x + t);
+    float gb = n + n * sin(3.0 * uva.y);
+    return vec3(r, gb * 0.8 * r, gb * r);
+}
+
+vec4 effect_color(vec2 pos) {
+ 
+    vec2 uv = (gl_FragCoord.xy - 0.5 * vec2(width, height)) / vec2(width, height);
+    uv *= (10.3 + 0.1 * sin(current_time * 0.01));
+
+
+
+    vec3 col = effect(0.001, uv, current_time, 0.5);
+
+    // Set the fragment color
+    fragColor = vec4(col, 1.0);
+
+
+    return vec4(fragColor);
+}
+
+)";
+
+
+
+
+
+
+
+
+
+// ported from https://www.shadertoy.com/view/3djfzy
+static const char *effect_ice_fragment =
+    R"(
+
+vec3 effect(float speed, vec2 uv, float time, float scale) {
+    float t = mod(time * 0.005, 6.0);
+    float rt = 0.00000000000001 * sin(t * 0.45);
+
+    mat2 m1 = mat2(cos(rt), -sin(rt), -sin(rt), cos(rt));
+    vec2 uva = uv * m1 * scale;
+    float irt = 0.005 * cos(t * 0.05);
+    mat2 m2 = mat2(sin(irt), cos(irt), -cos(irt), sin(irt));
+
+    for (int i = 1; i < 400; i += 1) {
+        float it = float(i);
+        uva *= m2;
+        uva.y += -1.0 + (0.6 / it) * cos(t + it * uva.x + 0.5 * it) * float(mod(it, 0.5) == 0.0);
+        uva.x += 1.0 + (0.5 / it) * cos(t + it * uva.y * 0.1 / 5.0 + 0.5 * (it + 15.0));
+    }
+
+    float n = 0.5;
+    float r = n + n * sin(4.0 * uva.x + t);
+    float gb = n + n * sin(3.0 * uva.y);
+    return vec3(r, gb * 0.8 * r, gb * r);
+}
+
+
+
+
+
+
+
+
+float rand(in vec2 _st) {
+    return fract(sin(dot(_st.xy, vec2(-0.820, -0.840))) * 4757.153);
+}
+
+float noise(in vec2 _st) {
+    const vec2 d = vec2(0.0, 1.0);
+    vec2 b = floor(_st), f = smoothstep(vec2(0.0), vec2(0.1, 0.3), fract(_st));
+    return mix(mix(rand(b), rand(b + d.yx), f.x), mix(rand(b + d.xy), rand(b + d.yy), f.x), f.y);
+}
+
+float fbm(in vec2 _st) {
+    float v = sin(current_time * 0.005) * 0.2;
+    float a = 0.3;
+    vec2 shift = vec2(100.0);
+    mat2 rot = mat2(cos(0.5), sin(1.0), -sin(0.5), acos(0.5));
+    for (int i = 0; i < 3; ++i) {
+        v += a * noise(_st);
+        _st = rot * _st * 2.0 + shift;
+        a *= 1.5;
+    }
+    return v;
+}
+
+vec4 effect_color(vec2 pos) {
+
+
+
+
+
+ vec2 st = (gl_FragCoord.xy * 2.0 - vec2(width, height)) / min(float(width), float(height)) * 0.5;
+
+    vec2 coord = st * 0.2;
+    float len;
+    for (int i = 0; i < 3; i++) {
+        len = length(coord);
+        coord.x += sin(coord.y + current_time * 0.001) * 2.1;
+        coord.y += cos(coord.x + current_time * 0.001 + cos(len * 1.0)) * 1.0;
+    }
+    len -= 3.0;
+
+    vec3 color = vec3(0.0);
+
+    vec2 q = vec2(0.0);
+    q.x = fbm(st);
+    q.y = fbm(st + vec2(-0.450, 0.650));
+
+    vec2 r = vec2(0.0);
+    r.x = fbm(st + 1.0 * q + vec2(0.570, 0.520) + 0.1 * current_time * 0.01);
+    r.y = fbm(st + 1.0 * q + vec2(0.340, -0.570) + 0.05 * current_time * 0.01);
+    float f = fbm(st + r);
+
+    color = mix(color, cos(len + vec3(0.5, 0.0, -0.1)), 1.0);
+    color = mix(vec3(0.478, 0.738, 0.760), vec3(0.563, 0.580, 0.667), color);
+
+    fragColor = vec4((f * f * f + .6 * f * f + .5 * f) * color, 1.0);
+
+
+    return vec4(fragColor);
+}
+)";
+
+
+
+
+
+static const char *effect_fire_fragment = R"(
+
+vec3 effect(float speed, vec2 uv, float time, float scale) {
+
+
+
+
+    float t = mod(time * 0.005, 6.0);
+    float rt = 0.00000000000001 * sin(t * 0.45);
+
+    mat2 m1 = mat2(cos(rt), -sin(rt), -sin(rt), cos(rt));
+    vec2 uva = uv * m1 * scale;
+    float irt = 0.005 * cos(t * 0.05);
+    mat2 m2 = mat2(sin(irt), cos(irt), -cos(irt), sin(irt));
+
+    for (int i = 1; i < 400; i += 1) {
+        float it = float(i);
+        uva *= m2;
+        uva.y += -1.0 + (0.6 / it) * cos(t + it * uva.x + 0.5 * it) * float(mod(it, 0.5) == 0.0);
+        uva.x += 1.0 + (0.5 / it) * cos(t + it * uva.y * 0.1 / 5.0 + 0.5 * (it + 15.0));
+    }
+
+    float n = 0.5;
+    float r = n + n * sin(4.0 * uva.x + t);
+    float gb = n + n * sin(3.0 * uva.y);
+    return vec3(r, gb * 0.8 * r, gb * r);
+}
+
+
+float rand(vec2 n) {
+    return fract(cos(dot(n, vec2(12.9898, 4.1414))) * 43758.5453);
+}
+
+float noise(vec2 n) {
+    const vec2 d = vec2(0.0, 1.0);
+    vec2 b = floor(n), f = smoothstep(vec2(0.0), vec2(1.0), fract(n));
+    return mix(mix(rand(b), rand(b + d.yx), f.x), mix(rand(b + d.xy), rand(b + d.yy), f.x), f.y);
+}
+
+float fbm(vec2 n) {
+    float total = 0.0, amplitude = 1.0;
+    for (int i = 0; i < 4; i++) {
+        total += noise(n) * amplitude;
+        n += n;
+        amplitude *= 0.5;
+    }
+    return total;
+}
+vec4 effect_color(vec2 pos) {
+ 
+ vec2 gid = gl_FragCoord.xy;
+    vec2 normalizedCoords = gid / vec2(width, height); // Normalize the coordinates
+
+    const vec3 c1 = vec3(0.5, 0.0, 0.1);
+    const vec3 c2 = vec3(0.9, 0.0, 0.0);
+    const vec3 c3 = vec3(0.2, 0.0, 0.0);
+    const vec3 c4 = vec3(1.0, 0.9, 0.0);
+    const vec3 c5 = vec3(0.1);
+    const vec3 c6 = vec3(0.9);
+
+    vec2 speed = vec2(0.7, 0.4);
+    float shift = 1.0;
+    float alpha = 1.0;
+
+    float timeEffect = current_time * 0.05; // Slowing down the animation by reducing the current_time factor
+
+    vec2 p = normalizedCoords * 8.0;
+    float q = fbm(p - timeEffect * 0.1);
+    vec2 r = vec2(fbm(p + q + timeEffect * speed.x - p.x - p.y), fbm(p + q - timeEffect * speed.y));
+    vec3 c = mix(c1, c2, fbm(p + r)) + mix(c3, c4, r.x) - mix(c5, c6, r.y);
+    fragColor = vec4(c * cos(shift * normalizedCoords.y), alpha);
+
+    
+    return vec4(fragColor);
+}
+
+)";
+
+
+
+
+static const char *effect_render_fragment = R"(
+
+precision lowp float;
+precision lowp sampler2D;
+
+uniform sampler2D in_b0d;
+uniform bool ink;
+uniform vec4 smoke_color;
+uniform vec4 decor_color;
+//uniform int regionInfo[20]; // This will likely go unused in this shader.
+
+//out vec4 fragColor;
+
+vec4 effect_color(vec2 pos) {
+
+  vec2 texCoord = gl_FragCoord.xy; // Assumes a fullscreen quad and matching texture size.
+    float c, a;
+    vec3 color;
+
+    vec4 s = texture(in_b0d, texCoord);
+    c = s.x * 800.0;
+    if (c > 255.0)
+        c = 255.0;
+    a = c / 255.0; // Normalize alpha to the range 0.0 to 1.0
+  if (ink)
+    {
+        if (c > 2.0)
+            color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
+        else
+            color = mix(decor_color.rgb, vec3(0.0, 0.0, 0.0), clamp(a, 0.0, 1.0));
+        
+        if (c > 1.5)
+            fragColor = vec4(color, 1.0);
+        else
+            fragColor = decor_color;
+    return vec4(fragColor);
+    }
+
+    else
+    {
+        color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
+   
+
+        fragColor = vec4(color, decor_color.a);
+return vec4(fragColor);
+   
+
+
+    }
+
+ fragColor = vec4(color, decor_color.a);
+return vec4(fragColor);
+    
+}
+
+
+
+)";
+
+
+
+
+
+

--- a/src/overlay-shaders.hpp
+++ b/src/overlay-shaders.hpp
@@ -1,0 +1,412 @@
+static const char *overlay_no_overlay = R"(
+vec4 overlay_function(vec2 position)
+{
+    return effect_color(position);
+})";
+
+static const char *overlay_rounded_corners = R"(
+uniform int corner_radius;
+uniform int shadow_radius;
+uniform vec4 shadow_color;
+
+vec4 overlay_function(vec2 pos)
+{
+    vec4 c = shadow_color;
+    vec4 m = vec4(0.0);
+    float diffuse = 1.0 / max(float(shadow_radius / 2), 1.0);
+
+    float distanceToEdgeX = ceil(min(pos.x, width - pos.x));
+    float distanceToEdgeY = ceil(min(pos.y, height - pos.y));
+
+    float radii_sum = float(shadow_radius) + float(corner_radius);
+
+    // We have a corner
+    if ((distanceToEdgeX <= radii_sum) && (distanceToEdgeY <= radii_sum))
+    {
+        float d = distance(vec2(distanceToEdgeX, distanceToEdgeY), vec2(radii_sum)) - float(corner_radius);
+        vec4 s = mix(c, m, 1.0 - exp(-pow(d * diffuse, 2.0)));
+
+        vec4 eff_color = effect_color(pos);
+        return mix(eff_color, s, clamp(d, 0.0, 1.0));
+    }
+
+    bool closeToX = ceil(distanceToEdgeX) < float(shadow_radius);
+    bool closeToY = ceil(distanceToEdgeY) < float(shadow_radius);
+
+    if (!closeToX && !closeToY)
+    {
+        return effect_color(pos);
+    }
+
+    // Edges
+    float d = float(shadow_radius) - (closeToX ? distanceToEdgeX : distanceToEdgeY);
+    return mix(c, m, 1.0 - exp(-pow(d * diffuse, 2.0)));
+})";
+
+
+
+
+static const char *overlay_beveled_glass = R"(
+
+
+#define MARKER_RADIUS 12.5
+#define THICCNESS 2.0
+
+uniform int beveled_radius;
+uniform int title_height;
+uniform int border_size;
+
+
+
+bool isInsideTriangle(vec2 p, vec2 a, vec2 b, vec2 c) {
+    vec2 v0 = b - a;
+    vec2 v1 = c - a;
+    vec2 v2 = p - a;
+
+    float dot00 = dot(v0, v0);
+    float dot01 = dot(v0, v1);
+    float dot02 = dot(v0, v2);
+    float dot11 = dot(v1, v1);
+    float dot12 = dot(v1, v2);
+
+    float invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
+    float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+
+    return (u >= 0.0) && (v >= 0.0) && (u + v <= 1.0);
+}
+
+
+vec4 toBezier(float delta, int i, vec4 P0, vec4 P1, vec4 P2, vec4 P3)
+{
+    float t = delta * float(i);
+    float t2 = t * t;
+    float one_minus_t = 1.0 - t;
+    float one_minus_t2 = one_minus_t * one_minus_t;
+    return (P0 * one_minus_t2 * one_minus_t + P1 * 3.0 * t * one_minus_t2 + P2 * 3.0 * t2 * one_minus_t + P3 * t2 * t);
+}
+
+float sin01(float x) {
+    return (sin(x) + 1.0) / 2.0;
+}
+
+
+
+
+
+vec4 drawCurveBenzier(vec2 p1, vec2 p2, int setCount) {
+    vec4 col = vec4(0.0);
+    vec2 fragCoord = gl_FragCoord.xy;
+    float curveRadius = float(beveled_radius/2);
+
+    for (int i = 0; i <= setCount; ++i) {
+        vec4 bezierPoint = toBezier(1.0 / float(setCount), i, vec4(p1, 0.0, 1.0), vec4(p1 + (p2 - p1) * 0.5, 0.0, 1.0), vec4(p1 + (p2 - p1) * 0.5, 0.0, 1.0), vec4(p2, 0.0, 1.0));
+        vec2 curvePoint = bezierPoint.xy / bezierPoint.w;
+        float distance = length(fragCoord - curvePoint);
+        float curveIntensity = smoothstep(0.0, THICCNESS, curveRadius - distance);
+        col.rgb += vec3(0.1, 0.1, 0.1) * curveIntensity;
+        col.a = max(col.a, curveIntensity);
+    }
+
+    return col;
+}
+
+
+
+vec4 drawCurve(vec2 p1, vec2 p2, int setCount) {
+    vec4 col = vec4(0.0);
+    ivec2 storePos = ivec2(gl_FragCoord.xy);
+
+    float curveRadius = float(beveled_radius + 1);
+    vec2 fragCoord = vec2(storePos);
+
+      float t = clamp(dot(fragCoord - p1, p2 - p1) / dot(p2 - p1, p2 - p1), 0.0, 1.0);
+    vec2 curvePoint = mix(p1, p2, t);
+
+    float distance = length(fragCoord - curvePoint);
+    float curveIntensity = smoothstep(0.0, curveRadius, curveRadius - distance);
+
+    // Calculate gradient along the line with grey to white to grey
+    vec3 gradientColor;
+
+    if (t < 0.5) {
+        gradientColor = mix(vec3(0.7), vec3(1.0), t * 2.0);
+    } else {
+        gradientColor = mix(vec3(1.0), vec3(0.7), (t - 0.5) * 2.0);
+    }
+
+    // Use the curveIntensity to interpolate between gradient colors
+    col.rgb = gradientColor * curveIntensity;
+    col.a = max(col.a, curveIntensity);
+
+    return col;
+}
+
+
+
+
+vec4 overlay_function(vec2 pos)
+{
+   
+
+
+vec2 fragCoord = gl_FragCoord.xy;
+
+    
+
+
+
+ vec4 col = vec4(0.0);
+    float space = 15.0; 
+
+    vec2 p1 = vec2(0.0 + THICCNESS, float(height) - THICCNESS - space);
+    vec2 p2 = vec2(0.0 + THICCNESS, 0.0 + THICCNESS + space);
+
+    vec2 x1 = vec2(float(width) - THICCNESS, float(height) - THICCNESS - space);
+    vec2 x2 = vec2(float(width) - THICCNESS, 0.0 + THICCNESS + space);
+
+    vec2 y1 = vec2(0.0 + THICCNESS + space, float(height) - THICCNESS);
+    vec2 y2 = vec2(float(width) - THICCNESS - space, float(height) - THICCNESS);
+
+    vec2 z1 = vec2(0.0 + THICCNESS + space, 0.0 + THICCNESS);
+    vec2 z2 = vec2(float(width) - THICCNESS - space, 0.0 + THICCNESS);
+
+
+ float curveRadius = float(beveled_radius);
+// Draw the lines connecting the points
+
+int setwidth = int(width);
+int setheight = int(height);
+
+
+if (setwidth<=400 && setheight<=300 ){
+    col += drawCurveBenzier(p1, p2, setheight);
+    col += drawCurveBenzier(x1, x2, setheight);
+    col += drawCurveBenzier(y1, y2, setwidth);
+    col += drawCurveBenzier(z1, z2, setwidth);
+}
+else {
+    col += drawCurve(p1, p2, setheight);
+    col += drawCurve(x1, x2, setheight);
+    col += drawCurve(y1, y2, setwidth);
+    col += drawCurve(z1, z2, setwidth);
+    }
+
+
+float INNERspace = 0.0; 
+
+
+
+
+//left
+    vec2 INNERp1 = vec2(0.0 - THICCNESS+ float(border_size), float(height)   + THICCNESS -float(title_height) );
+    vec2 INNERp2 = vec2(0.0 - THICCNESS+ float(border_size),0.0 - THICCNESS + INNERspace+float(border_size));
+//right     
+    vec2 INNERx1 = vec2(float(width) + THICCNESS-float(border_size), float(height)   + THICCNESS -float(title_height));
+    vec2 INNERx2 = vec2(float(width) + THICCNESS-float(border_size),0.0 - THICCNESS + INNERspace+float(border_size));
+
+
+//top
+    vec2 INNERy1 = vec2(0.0 + THICCNESS + INNERspace+float(border_size), float(height)   + THICCNESS -float(title_height));
+    vec2 INNERy2 = vec2(float(width) - THICCNESS - INNERspace-float(border_size), float(height) + THICCNESS-float(title_height));
+
+//bottom
+   vec2 INNERz1 = vec2(0.0 +INNERspace+float(border_size), 0.0 - THICCNESS + INNERspace+float(border_size));
+    vec2 INNERz2 = vec2(float(width) - THICCNESS - INNERspace-float(border_size) ,0.0 - THICCNESS + INNERspace+float(border_size) );
+
+
+
+
+
+if (setwidth<=400 && setheight<=300 ){
+    col += drawCurveBenzier(INNERp1, INNERp2, setheight);
+    col += drawCurveBenzier(INNERx1, INNERx2, setheight);
+    col += drawCurveBenzier(INNERy1, INNERy2, setwidth);
+    col += drawCurveBenzier(INNERz1, INNERz2, setwidth);
+}
+else{
+    col += drawCurve(INNERp1, INNERp2, setheight);
+    col += drawCurve(INNERx1, INNERx2, setheight);
+    col += drawCurve(INNERy1, INNERy2, setwidth);
+    col += drawCurve(INNERz1, INNERz2, setwidth);
+    }
+
+
+    vec2 p3 = fragCoord;
+    vec2 p12 = p2 - p1;
+    vec2 p13 = p3 - p1;
+
+    vec2 x3 = fragCoord;
+    vec2 x12 = x2 - x1;
+    vec2 x13 = x3 - x1;
+
+    vec2 y3 = fragCoord;
+    vec2 y12 = y2 - y1;
+    vec2 y13 = y3 - y1;
+
+    vec2 z3 = fragCoord;
+    vec2 z12 = z2 - z1;
+    vec2 z13 = z3 - z1;
+
+    float d = dot(p12, p13) / length(p12); // = length(p13) * cos(angle)
+    float dx = dot(x12, x13) / length(x12);
+    float dy = dot(y12, y13) / length(y12);
+    float dz = dot(z12, z13) / length(z12);
+
+    vec2 p4 = p1 + normalize(p12) * d;
+    vec2 x4 = x1 + normalize(x12) * dx;
+    vec2 y4 = y1 + normalize(y12) * dy;
+    vec2 z4 = z1 + normalize(z12) * dz;
+
+
+    if (((length(p4 - p3) < THICCNESS && length(p4 - p1) <= length(p12) && length(p4 - p2) <= length(p12)) ||
+         (length(x4 - x3) < THICCNESS && length(x4 - x1) <= length(x12) && length(x4 - x2) <= length(x12))) ||
+         (length(y4 - y3) < THICCNESS && length(y4 - y1) <= length(y12) && length(y4 - y2) <= length(y12)) ||
+         (length(z4 - z3) < THICCNESS && length(z4 - z1) <= length(z12) && length(z4 - z2) <= length(z12))) { 
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+    
+
+   
+    vec2 INNERp3 = fragCoord;
+    vec2 INNERp12 = INNERp2 - INNERp1;
+    vec2 INNERp13 = INNERp3 - INNERp1;
+
+    vec2 INNERx3 = fragCoord;
+    vec2 INNERx12 = INNERx2 - INNERx1;
+    vec2 INNERx13 = INNERx3 - INNERx1;
+
+    vec2 INNERy3 = fragCoord;
+    vec2 INNERy12 = INNERy2 - INNERy1;
+    vec2 INNERy13 = INNERy3 - INNERy1;
+
+    vec2 INNERz3 = fragCoord;
+    vec2 INNERz12 = INNERz2 - INNERz1;
+    vec2 INNERz13 = INNERz3 - INNERz1;
+
+    float INNERd = dot(INNERp12, INNERp13) / length(INNERp12); // = length(p13) * cos(angle)
+    float INNERdx = dot(INNERx12, INNERx13) / length(INNERx12);
+    float INNERdy = dot(INNERy12, INNERy13) / length(INNERy12);
+    float INNERdz = dot(INNERz12, INNERz13) / length(INNERz12);
+
+    vec2 INNERp4 = INNERp1 + normalize(INNERp12) * INNERd;
+    vec2 INNERx4 = INNERx1 + normalize(INNERx12) * INNERdx;
+    vec2 INNERy4 = INNERy1 + normalize(INNERy12) * INNERdy;
+    vec2 INNERz4 = INNERz1 + normalize(INNERz12) * INNERdz;
+    
+       if (((length(INNERp4 - INNERp3) < THICCNESS && length(INNERp4 - INNERp1) <= length(INNERp12) && length(INNERp4 - INNERp2) <= length(INNERp12)) ||
+         (length(INNERx4 - INNERx3) < THICCNESS && length(INNERx4 - INNERx1) <= length(INNERx12) && length(INNERx4 - INNERx2) <= length(INNERx12))) ||
+         (length(INNERy4 - INNERy3) < THICCNESS && length(INNERy4 - INNERy1) <= length(INNERy12) && length(INNERy4 - INNERy2) <= length(INNERy12)) ||
+         (length(INNERz4 - INNERz3) < THICCNESS && length(INNERz4 - INNERz1) <= length(INNERz12) && length(INNERz4 - INNERz2) <= length(INNERz12))) { 
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }       
+
+
+    // Draw the lines connecting the points
+       // Calculate the line segment connecting p1 and y1
+    vec2 dir = normalize(y1 - p1);
+    vec2 relPoint = fragCoord - p1;
+    float alongLine = dot(relPoint, dir);
+    float distance = length(relPoint - alongLine * dir);
+
+    // Draw the line connecting p1 and y1
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(y1 - p1)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+
+    
+    dir = normalize(y2 - x1);
+    relPoint = fragCoord - x1;
+     alongLine = dot(relPoint, dir);
+     distance = length(relPoint - alongLine * dir);
+
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(x1 - y2)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+
+ dir = normalize(p2 - z1);
+    relPoint = fragCoord - z1;
+     alongLine = dot(relPoint, dir);
+     distance = length(relPoint - alongLine * dir);
+
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(z1 - p2)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+
+
+
+ dir = normalize(x2 - z2);
+    relPoint = fragCoord - z2;
+     alongLine = dot(relPoint, dir);
+     distance = length(relPoint - alongLine * dir);
+
+    if (distance < THICCNESS && alongLine > 0.0 && alongLine < length(x2 - z2)) {
+        col = vec4(0.1, 0.1, 0.1, 1.0);
+    }
+    // Draw other lines...
+
+    vec2 t1 = vec2(0.0, float(height));
+    vec2 t2 = vec2(float(width), float(height));
+    vec2 t3 = vec2(-0.5, -0.5);
+    vec2 t4 = vec2(float(width), -0.5);
+
+
+   
+vec4 combine_col= col+effect_color(pos);
+  
+
+
+
+
+int shadow_radius=-0;
+int corner_radius=15;
+
+
+vec4 c = vec4(1.0);
+vec4 m = vec4(0.0, 0.0, 0.0, 0.0); // Transparent for the cut corners
+float diffuse = 1.0 / max(float(shadow_radius / 2), 1.0);
+
+float distanceToEdgeX = ceil(min(pos.x, width - pos.x));
+float distanceToEdgeY = ceil(min(pos.y, height - pos.y));
+
+float radii_sum = float(shadow_radius) + float(corner_radius);
+
+// Check for 45-degree cut corners
+if ((distanceToEdgeX <= radii_sum) && (distanceToEdgeY <= radii_sum))
+{
+    // Calculate if within the 45-degree triangle area
+    float diagonalDistance = distanceToEdgeX + distanceToEdgeY;
+    if (diagonalDistance <= radii_sum) {
+        // Inside the cut corner area, make it fully transparent
+        return m; // Return transparent color
+    }
+}
+
+/*
+bool closeToX = distanceToEdgeX < float(shadow_radius);
+bool closeToY = distanceToEdgeY < float(shadow_radius);
+
+if (!closeToX && !closeToY)
+{
+  //  return effect_color(pos);
+}
+
+// Handle shadow along edges
+float shadow_d = float(shadow_radius) - (closeToX ? distanceToEdgeX : distanceToEdgeY);
+vec4 edgeShadow = mix(c, m, 1.0 - exp(-pow(shadow_d  * diffuse, 2.0)));
+vec4 shadow = vec4(edgeShadow.rgb, edgeShadow.a * clamp(1.0 - shadow_d  / float(shadow_radius), 0.0, 1.0)); // Adjust alpha to fade shadow
+*/
+
+ return combine_col;
+  
+})";
+
+
+
+
+
+
+
+

--- a/src/smoke-shaders.hpp
+++ b/src/smoke-shaders.hpp
@@ -1,0 +1,1755 @@
+static const char *motion_source =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
+layout (binding = 2, r32f) uniform readonly image2D in_b0v;
+layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 3) uniform int px;
+layout(location = 4) uniform int py;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+layout(location = 7) uniform int rand1;
+layout(location = 8) uniform int rand2;
+layout(location = 9) uniform int radius;
+
+void motion(int x, int y)
+{
+	int i, i0, i1, j, j0, j1, d = 2;
+
+	if (x - d < 1)
+		i0 = 1;
+	else
+		i0 = x - d;
+	if (i0 + 2 * d > width - 1)
+		i1 = width - 1;
+	else
+		i1 = i0 + 2 * d;
+
+	if (y - d < 1)
+		j0 = 1;
+	else
+		j0 = y - d;
+	if (j0 + 2 * d > height - 1)
+		j1 = height - 1;
+	else
+		j1 = j0 + 2 * d;
+
+	for (i = i0; i < i1; i++)
+	{
+		for (j = j0; j < j1; j++) {
+			if (i < radius || j < radius || i > (width - 1) - radius || j > (height - 1) - radius || (i > border_size && i < (width - 1) - border_size && j > (title_height - 1) && j < (height - 1) - border_size))
+			{
+				continue;
+			}
+			vec4 b0u = imageLoad(in_b0u, ivec2(i, j));
+			vec4 b0v = imageLoad(in_b0v, ivec2(i, j));
+			vec4 b0d = imageLoad(in_b0d, ivec2(i, j));
+			float u = b0u.x;
+			float v = b0v.x;
+			float d = b0d.x;
+			imageStore(out_b0u, ivec2(i, j), vec4(u + float(256 - (rand1 & 512)), 0.0, 0.0, 0.0));
+			imageStore(out_b0v, ivec2(i, j), vec4(v + float(256 - (rand2 & 512)), 0.0, 0.0, 0.0));
+			imageStore(out_b0d, ivec2(i, j), vec4(d + 1.0, 0.0, 0.0, 0.0));
+		}
+	}
+}
+
+void main()
+{
+    motion(px, py);
+}
+)";
+
+// Generic smoke shader beginning
+static const char *smoke_header =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 0, rgba32f) uniform readonly image2D in_tex;
+layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
+layout (binding = 2, r32f) uniform readonly image2D in_b0v;
+layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
+layout (binding = 4, r32f) uniform readonly image2D in_b1u;
+layout (binding = 4, r32f) uniform writeonly image2D out_b1u;
+layout (binding = 5, r32f) uniform readonly image2D in_b1v;
+layout (binding = 5, r32f) uniform writeonly image2D out_b1v;
+layout (binding = 6, r32f) uniform readonly image2D in_b1d;
+layout (binding = 6, r32f) uniform writeonly image2D out_b1d;
+layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+layout(location = 10) uniform int regionInfo[20];
+)";
+
+// Generic main method for a compute shader which runs for a particular region
+static const char *effect_run_for_region_main =
+    R"(
+void main()
+{
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    int z = int(gl_GlobalInvocationID.z);
+
+    ivec4 myRegion = ivec4(regionInfo[z * 5], regionInfo[z * 5 + 1], regionInfo[z * 5 + 2], regionInfo[z * 5 + 3]);
+    if (regionInfo[z * 5 + 4] > 0)
+    {
+        pos = pos.yx;
+    }
+
+    if (all(lessThan(pos, myRegion.zw)))
+    {
+        pos += myRegion.xy;
+        run_pixel(pos.x, pos.y);
+    }
+})";
+
+static const char *diffuse1_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k;
+	float t, a = 0.0002;
+
+	vec4 s = imageLoad(in_b0u, ivec2(x, y));
+	vec4 d1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 d2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 d3 = imageLoad(in_b1u, ivec2(x, y - 1));
+	vec4 d4 = imageLoad(in_b1u, ivec2(x, y + 1));
+	float sx = s.x;
+	float du1 = d1.x;
+	float du2 = d2.x;
+	float du3 = d3.x;
+	float du4 = d4.x;
+	float t1 = du1 + du2 + du3 + du4;
+	s = imageLoad(in_b0v, ivec2(x, y));
+	d1 = imageLoad(in_b1v, ivec2(x - 1, y));
+	d2 = imageLoad(in_b1v, ivec2(x + 1, y));
+	d3 = imageLoad(in_b1v, ivec2(x, y - 1));
+	d4 = imageLoad(in_b1v, ivec2(x, y + 1));
+	float sy = s.x;
+	du1 = d1.x;
+	du2 = d2.x;
+	du3 = d3.x;
+	du4 = d4.x;
+	float t2 = du1 + du2 + du3 + du4;
+	imageStore(out_b1u, ivec2(x, y), vec4((sx + a * t1) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4((sy + a * t2) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
+}
+)";
+
+static const char *project1_source =
+    R"(
+void run_pixel(int x, int y) {
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b1v, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b1v, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float v1 = s3.x;
+	float v2 = s4.x;
+	imageStore(out_b0u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
+	imageStore(out_b0v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
+}
+)";
+
+static const char *project2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0 = imageLoad(in_b0v, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b0u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+})";
+
+static const char *project3_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0x = imageLoad(in_b1u, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s0y = imageLoad(in_b1v, ivec2(x, y));
+	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+	float su = s0x.x;
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float sv = s0y.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b1u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+})";
+
+static const char *advect1_source =
+    R"(
+void run_pixel(int x, int y) /* b1.u, b1.v, b1.u, b0.u */
+{
+	int stride;
+	int i, j;
+	float fx, fy;
+	stride = width;
+
+	vec4 sx = imageLoad(in_b1u, ivec2(x, y));
+	vec4 sy = imageLoad(in_b1v, ivec2(x, y));
+	float ix = float(x) - sx.x;
+	float iy = float(y) - sy.x;
+	if (ix < 0.5)
+		ix = 0.5;
+	if (iy < 0.5)
+		iy = 0.5;
+	if (ix > float(width) - 1.5)
+		ix = float(width) - 1.5;
+	if (iy > float(height) - 1.5)
+		iy = float(height) - 1.5;
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+	vec4 s0x = imageLoad(in_b1u, ivec2(i,     j));
+	vec4 s1x = imageLoad(in_b1u, ivec2(i + 1, j));
+	vec4 s2x = imageLoad(in_b1u, ivec2(i,     j + 1));
+	vec4 s3x = imageLoad(in_b1u, ivec2(i + 1, j + 1));
+	float p1 = (s0x.x * (1.0 - fx) + s1x.x * fx) * (1.0 - fy) + (s2x.x * (1.0 - fx) + s3x.x * fx) * fy;
+	imageStore(out_b0u, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+	ix = float(x) - sx.x;
+	iy = float(y) - sy.x;
+	if (ix < 0.5)
+		ix = 0.5;
+	if (iy < 0.5)
+		iy = 0.5;
+	if (ix > float(width) - 1.5)
+		ix = float(width) - 1.5;
+	if (iy > float(height) - 1.5)
+		iy = float(height) - 1.5;
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+	vec4 s0y = imageLoad(in_b1v, ivec2(i,     j));
+	vec4 s1y = imageLoad(in_b1v, ivec2(i + 1, j));
+	vec4 s2y = imageLoad(in_b1v, ivec2(i,     j + 1));
+	vec4 s3y = imageLoad(in_b1v, ivec2(i + 1, j + 1));
+	float p2 = (s0y.x * (1.0 - fx) + s1y.x * fx) * (1.0 - fy) + (s2y.x * (1.0 - fx) + s3y.x * fx) * fy;
+	imageStore(out_b0v, ivec2(x, y), vec4(p2, 0.0, 0.0, 0.0));
+})";
+
+static const char *project4_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b0v, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0v, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float v1 = s3.x;
+	float v2 = s4.x;
+	imageStore(out_b1u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
+})";
+
+static const char *project5_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0 = imageLoad(in_b1v, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b1u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b1u, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b1u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+})";
+
+static const char *project6_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0x = imageLoad(in_b0u, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 s0y = imageLoad(in_b0v, ivec2(x, y));
+	vec4 s3 = imageLoad(in_b1u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b1u, ivec2(x, y + 1));
+	float su = s0x.x;
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float sv = s0y.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b0u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+	imageStore(out_b0v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+})";
+
+static const char *diffuse2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, stride;
+	float t, a = 0.0002;
+	stride = width;
+
+	vec4 s = imageLoad(in_b0d, ivec2(x, y));
+	vec4 d1 = imageLoad(in_b1d, ivec2(x - 1, y));
+	vec4 d2 = imageLoad(in_b1d, ivec2(x + 1, y));
+	vec4 d3 = imageLoad(in_b1d, ivec2(x, y - 1));
+	vec4 d4 = imageLoad(in_b1d, ivec2(x, y + 1));
+	float sz = s.x;
+	float du1 = d1.x;
+	float du2 = d2.x;
+	float du3 = d3.x;
+	float du4 = d4.x;
+	t = du1 + du2 + du3 + du4;
+	imageStore(out_b1d, ivec2(x, y), vec4((sz + a * t) / (1.0 + 4.0 * a) * 0.995, 0.0, 0.0, 0.0));
+})";
+
+static const char *advect2_source =
+    R"(
+void run_pixel(int x, int y) /*b0u, b0v, b1d, b0d*/
+{
+	int stride;
+	int i, j;
+	float fx, fy;
+	stride = width;
+
+	vec4 sx = imageLoad(in_b0u, ivec2(x, y));
+	vec4 sy = imageLoad(in_b0v, ivec2(x, y));
+	float ix = float(x) - sx.x;
+	float iy = float(y) - sy.x;
+	if (ix < 0.5)
+		ix = 0.5;
+	if (iy < 0.5)
+		iy = 0.5;
+	if (ix > float(width) - 1.5)
+		ix = float(width) - 1.5;
+	if (iy > float(height) - 1.5)
+		iy = float(height) - 1.5;
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+	vec4 s0z = imageLoad(in_b1d, ivec2(i,     j));
+	vec4 s1z = imageLoad(in_b1d, ivec2(i + 1, j));
+	vec4 s2z = imageLoad(in_b1d, ivec2(i,     j + 1));
+	vec4 s3z = imageLoad(in_b1d, ivec2(i + 1, j + 1));
+	float p1 = (s0z.x * (1.0 - fx) + s1z.x * fx) * (1.0 - fy) + (s2z.x * (1.0 - fx) + s3z.x * fx) * fy;
+	imageStore(out_b0d, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+})";
+
+static const char *render_source =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 4) uniform bool ink;
+layout(location = 8) uniform vec4 smoke_color;
+layout(location = 9) uniform vec4 decor_color;
+layout(location = 10) uniform int regionInfo[20];
+
+void run_pixel(int x, int y)
+{
+	float c, r, g, b, a;
+
+	vec4 s = imageLoad(in_b0d, ivec2(x, y));
+	c = s.x * 800.0;
+	if (c > 255.0)
+		c = 255.0;
+	a = c;
+	vec3 color;
+	if (ink)
+	{
+		if (c > 2.0)
+			color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
+		else
+			color = mix(decor_color.rgb, vec3(0.0, 0.0, 0.0), clamp(a, 0.0, 1.0));
+		if (c > 1.5)
+			imageStore(out_tex, ivec2(x, y), vec4(color, 1.0));
+		else
+			imageStore(out_tex, ivec2(x, y), decor_color);
+		return;
+	} else
+	{
+		color = mix(decor_color.rgb, smoke_color.rgb, clamp(a, 0.0, 1.0));
+	}
+	imageStore(out_tex, ivec2(x, y), vec4(color, decor_color.a));
+})";
+
+/*///////////////////////////////////////////////
+	  ______  _    _  __  __  ______   _____ 
+	 |  ____|| |  | ||  \/  ||  ____| / ____|
+	 | |__   | |  | || \  / || |__    | (___   
+	 |  __|  | |  | || |\/| ||  __|    \___ \
+	 | |     | |__| || |  | || |____   ____) |
+	 |_|      \____/ |_|  |_||______| |_____/ 
+
+*////////////////////////////////////////////////
+
+static const char *fumes_motion_source =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
+layout (binding = 2, r32f) uniform readonly image2D in_b0v;
+layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 3) uniform int px;
+layout(location = 4) uniform int py;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+layout(location = 7) uniform int rand1;
+layout(location = 8) uniform int rand2;
+layout(location = 9) uniform int radius;
+
+void motion(int x, int y)
+{
+	int i, i0, i1, j, j0, j1, d = 2;
+
+	if (x - d < 1)
+		i0 = 1;
+	else
+		i0 = x - d;
+	if (i0 + 2 * d > width - 1)
+		i1 = width - 1;
+	else
+		i1 = i0 + 2 * d;
+
+	if (y - d < 1)
+		j0 = 1;
+	else
+		j0 = y - d;
+	if (j0 + 2 * d > height - 1)
+		j1 = height - 1;
+	else
+		j1 = j0 + 2 * d;
+
+	for (i = i0; i < i1; i++)
+	{
+		for (j = j0; j < j1; j++) {
+			if (i < radius || j < radius || i > (width - 1) - radius || j > (height - 1) - radius || (i > border_size && i < (width - 1) - border_size && j > (title_height - 1) && j < (height - 1) - border_size))
+			{
+				continue;
+			}
+			vec4 b0u = imageLoad(in_b0u, ivec2(i, j));
+			vec4 b0v = imageLoad(in_b0u, ivec2(i, j));
+			vec4 b0d = imageLoad(in_b0u, ivec2(i, j));
+			float u = b0u.x;
+			float v = b0v.x;
+			float d = b0d.x;
+			imageStore(out_b0u, ivec2(i, j), vec4(u + float(256*15 - (rand1 & 512*15)), 0.0, 0.0, 0.0));
+			imageStore(out_b0v, ivec2(i, j), vec4(v + float(256*15 - (rand2 & 512*15)), 0.0, 0.0, 0.0));
+		//	imageStore(out_b0d, ivec2(i, j), vec4(0.0, 0.0, 0.0, 0.0));
+		}
+	}
+	}
+
+void main()
+{
+    motion(px, py);
+}
+)";
+
+static const char *fumes_diffuse1_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k;
+	float t = 0.0002;
+	float a = 0.002;
+	vec4 s = imageLoad(in_b0u, ivec2(x, y));
+	vec4 d1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 d2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 d3 = imageLoad(in_b1u, ivec2(x, y - 1));
+	vec4 d4 = imageLoad(in_b1u, ivec2(x, y + 1));
+	float sx = s.x;
+	float du1 = d1.x;
+	float du2 = d2.x;
+	float du3 = d3.x;
+	float du4 = d4.x;
+	float t1 = du1 + du2 + du3 + du4;
+	s = imageLoad(in_b0v, ivec2(x, y));
+	d1 = imageLoad(in_b1v, ivec2(x - 1, y));
+	d2 = imageLoad(in_b1v, ivec2(x + 1, y));
+	d3 = imageLoad(in_b1v, ivec2(x, y - 1));
+	d4 = imageLoad(in_b1v, ivec2(x, y + 1));
+	float sy = s.x;
+	du1 = d1.x;
+	du2 = d2.x;
+	du3 = d3.x;
+	du4 = d4.x;
+	float t2 = du1 + du2 + du3 + du4;
+	imageStore(out_b1u, ivec2(x, y), vec4((sx + a * t1) / (1.0 + 4.0 * a) * 0.9999999999999999999999995, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4((sy + a * t2) / (1.0 + 4.0 * a) * 0.9999999999999999999999995, 0.0, 0.0, 0.0));
+
+
+}
+)";
+
+static const char *fumes_project1_source =
+    R"(
+void run_pixel(int x, int y) {
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+//	s = width;
+
+	vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b1v, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b1v, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float v1 = s3.x;
+	float v2 = s4.x;
+	imageStore(out_b0u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
+	imageStore(out_b0v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
+}
+)";
+
+static const char *fumes_project2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0 = imageLoad(in_b0v, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+
+	imageStore(out_b0u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+})";
+
+static const char *fumes_project3_source =
+    R"(
+void run_pixel(int x, int y)
+{
+	int k, l, s;
+	float h;
+
+	h = 1.0 / float(width);
+	s = width;
+
+	vec4 s0x = imageLoad(in_b1u, ivec2(x, y));
+	vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+	vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+	vec4 s0y = imageLoad(in_b1v, ivec2(x, y));
+	vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+	vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+	float su = s0x.x;
+	float u1 = s1.x;
+	float u2 = s2.x;
+	float sv = s0y.x;
+	float u3 = s3.x;
+	float u4 = s4.x;
+	imageStore(out_b1u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+	imageStore(out_b1v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+})";
+
+static const char *fumes_advect1_source =
+    R"(
+
+void run_pixel(int x, int y) /* b1.u, b1.v, b1.u, b0.u */
+{
+	int stride;
+	int i, j;
+	float fx, fy;
+	stride = width;
+
+	vec4 sx = imageLoad(in_b1u, ivec2(x, y));
+	vec4 sy = imageLoad(in_b1v, ivec2(x, y));
+	float ix = float(x) - sx.x;
+	float iy = float(y) - sy.x;
+	
+
+	ix = clamp(ix, 0.5, float(width) - 1.5);
+	iy = clamp(iy, 0.5, float(height) - 1.5);
+
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+
+	// Process u component
+	vec4 s0x = imageLoad(in_b1u, ivec2(i, j));
+	vec4 s1x = imageLoad(in_b1u, ivec2(i + 1, j));
+	vec4 s2x = imageLoad(in_b1u, ivec2(i, j + 1));
+	vec4 s3x = imageLoad(in_b1u, ivec2(i + 1, j + 1));
+	float p1 = (s0x.x * (1.0 - fx) + s1x.x * fx) * (1.0 - fy) + (s2x.x * (1.0 - fx) + s3x.x * fx) * fy;
+	imageStore(out_b0u, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+
+	ix = float(x) - sx.x;
+	iy = float(y) - sy.x;
+
+	ix = clamp(ix, 0.5, float(width) - 1.5);
+	iy = clamp(iy, 0.5, float(height) - 1.5);
+	
+	i = int(ix);
+	j = int(iy);
+	fx = ix - float(i);
+	fy = iy - float(j);
+
+	// Process v component
+	vec4 s0y = imageLoad(in_b1v, ivec2(i, j));
+	vec4 s1y = imageLoad(in_b1v, ivec2(i + 1, j));
+	vec4 s2y = imageLoad(in_b1v, ivec2(i, j + 1));
+	vec4 s3y = imageLoad(in_b1v, ivec2(i + 1, j + 1));
+	float p2 = (s0y.x * (1.0 - fx) + s1y.x * fx) * (1.0 - fy) + (s2y.x * (1.0 - fx) + s3y.x * fx) * fy;
+	imageStore(out_b0v, ivec2(x, y), vec4(p2, 0.0, 0.0, 0.0));
+})";
+
+static const char *fumes_project4_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fumes_project5_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fumes_project6_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fumes_diffuse2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fumes_advect2_source =
+    R"(
+void run_pixel(int x, int y) 
+{
+
+})";
+
+//math from https://inria.hal.science/inria-00596050/document
+static const char *fumes_render_source =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 4) uniform bool ink;
+layout(location = 8) uniform vec4 smoke_color;
+layout(location = 9) uniform vec4 decor_color;
+layout(location = 10) uniform int regionInfo[20];
+
+
+const float K = 1000.0;
+const float v = 0.0000000000005; // Viscosity
+const vec2 Step = vec2(0.005, 0.005); // Texture step for resolution
+const vec4 ExternalForces = vec4(-0.0, 0.0, 10.0, 0.0);
+const float dt = -0.2; // Constant small time step
+
+bool IsBoundary(vec2 UV) {
+    // Implement your boundary condition check here
+    return false;
+}
+
+float rand(vec2 uv) {
+    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+
+void run_pixel(int x, int y)
+{
+
+
+    ivec2 coords = ivec2(x, y);
+    vec2 UV = (vec2(coords) + 0.5) / vec2(imageSize(in_b0d));
+
+
+
+    float CScale = 1.0 / 2.0;
+    float S = K / dt;
+    
+    vec4 FC = imageLoad(in_b0d, ivec2(x, y));
+    vec4 FR = imageLoad(in_b0d, ivec2(x + 1, y));
+    vec4 FL = imageLoad(in_b0d, ivec2(x - 1, y));
+    vec4 FT = imageLoad(in_b0d, ivec2(x, y + 1));
+    vec4 FD = imageLoad(in_b0d, ivec2(x, y - 1));
+
+
+ mat4 FieldMat = mat4(FR, FL, FT, FD);
+    // du/dx, du/dy
+    vec3 UdX = (FieldMat[0].xyz - FieldMat[1].xyz) * CScale;
+    vec3 UdY = (FieldMat[2].xyz - FieldMat[3].xyz) * CScale;
+    float Udiv = UdX.x + UdY.y;
+    vec2 DdX = vec2(UdX.z, UdY.z);
+    // Solve for density.
+    FC.z -= dt * dot(vec3(DdX, Udiv), FC.xyz);
+    // Related to stability.
+    FC.z = clamp(FC.z, 0.5, 3.0);
+    // Solve for Velocity.
+    vec2 PdX = S * DdX;
+    vec2 Laplacian = vec2(1.0) * dot(vec4(1.0), vec4(FieldMat)) - 4.0 * FC.xy;
+    vec2 ViscosityForce = v * Laplacian;
+    // Semi-lagrangian advection.
+    // Assuming you want to change the direction along the x-axis:
+// Adjust the texture coordinates accordingly to change the direction of advection
+
+// Update the texture coordinates for advection
+vec2 Was = UV - dt * FC.xy * Step;
+
+// Modify the texture coordinates based on the desired direction
+// For example, to change the direction along the y-axis:
+ Was.y = UV.y - dt * FC.y * Step.y;
+Was.x = UV.x + dt * FC.x * Step.x;
+// Convert Was to texture coordinates
+Was = Was * vec2(imageSize(in_b0u));
+
+// Sample the velocity texture using the updated coordinates
+vec2 newVelocity = imageLoad(in_b0u, ivec2(Was)).xy;
+
+// Update FC.xy with the new velocity
+FC.xy = newVelocity;
+
+
+  FC.xy = imageLoad(in_b0u, ivec2(Was)).xy;
+    FC.xy += dt * (ViscosityForce - PdX + ExternalForces.xy);
+
+  // Output
+ //   imageStore(out_tex, coords, FC* 1.0);
+
+// Calculate the density value
+float density = FC.x;
+
+// Define a threshold to determine the blend factor
+float threshold = 0.02;
+
+
+//vec4 blendedColor = mix(vec4(1.0,0.0,0.0,FC*-10.0), vec4(0.0,0.0,0.0,FC*1.0), smoothstep(0.0, 1.0, density / threshold));
+
+// Blend between the two colors based on the density value
+//vec4 blendedColor = mix(vec4(1.0,0.0,0.0,FC*-10.0), vec4(1.0,1.0,1.0,FC*1.0), smoothstep(0.0, 1.0, density / threshold));
+//vec4 blendedColor = mix(vec4(1.0,1.0,1.0,FC*-10.0), vec4(0.0,0.0,0.0,FC*1.0), smoothstep(0.0, 1.0, density / threshold));
+
+
+   // Inside the pixel processing loop
+    vec2 seed = vec2(34.0, 78.0); // Initial seed values
+
+ // Inside the pixel processing loop
+    vec2 seed2 = vec2(14.0, 98.0); // Initial seed values
+ // Inside the pixel processing loop
+    vec2 seed3 = vec2(49.0, 178.0); // Initial seed values
+
+
+// Generate pseudo-random numbers based on the pixel coordinates (x, y)
+float randomValueR = rand(UV + seed);
+float randomValueG = rand(UV + 2.0 * seed2); // Use a different seed for green to ensure variety
+float randomValueB = rand(UV + 3.0 * seed3); // Use another different seed for blue
+
+// Create a random color using the random values for each component
+vec4 randomColor = vec4(randomValueR, randomValueG, randomValueB,  smoothstep(0.0, 1.0, density / threshold));
+
+    // Add the random color to the smoke color
+    vec4 smokeWithRandomColor = smoke_color;
+
+
+
+
+vec4 blendedColor = mix(vec4(vec4(smokeWithRandomColor.r*.5,smokeWithRandomColor.g*.5,smokeWithRandomColor.b*-0.5,FC*-10.0)), vec4(smokeWithRandomColor.r,smokeWithRandomColor.g,smokeWithRandomColor.b,FC*1.0), smoothstep(0.0, 1.0, density / threshold));
+
+// Output the blended color
+//imageStore(out_tex, coords, blendedColor);
+
+// Blend the decor color with the blended smoke color
+vec4 finalColor = mix(decor_color, blendedColor, blendedColor.a);
+
+// Output the final color
+imageStore(out_tex, coords, finalColor);
+})";
+
+
+
+
+/*///////////////////////////////////////////////
+          _____ 
+         / ____|
+         | (___   
+   fast  \ ___ \ moke
+         ____) |
+        |_____/ 
+
+*////////////////////////////////////////////////
+
+static const char *fast_smoke_motion_source =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
+layout (binding = 2, r32f) uniform readonly image2D in_b0v;
+layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 3) uniform int px;
+layout(location = 4) uniform int py;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+layout(location = 7) uniform int rand1;
+layout(location = 8) uniform int rand2;
+layout(location = 9) uniform int radius;
+
+void motion(int x, int y)
+{
+    int i, i0, i1, j, j0, j1, d = 2;
+
+    if (x - d < 1)
+        i0 = 1;
+    else
+        i0 = x - d;
+    if (i0 + 2 * d > width - 1)
+        i1 = width - 1;
+    else
+        i1 = i0 + 2 * d;
+
+    if (y - d < 1)
+        j0 = 1;
+    else
+        j0 = y - d;
+    if (j0 + 2 * d > height - 1)
+        j1 = height - 1;
+    else
+        j1 = j0 + 2 * d;
+
+    for (i = i0; i < i1; i++)
+    {
+        for (j = j0; j < j1; j++) {
+            if (i < radius || j < radius || i > (width - 1) - radius || j > (height - 1) - radius || (i > border_size && i < (width - 1) - border_size && j > (title_height - 1) && j < (height - 1) - border_size))
+            {
+                continue;
+            }
+            vec4 b0u = imageLoad(in_b0u, ivec2(i, j));
+            vec4 b0v = imageLoad(in_b0u, ivec2(i, j));
+            vec4 b0d = imageLoad(in_b0u, ivec2(i, j));
+            float u = b0u.x;
+            float v = b0v.x;
+            float d = b0d.x;
+            imageStore(out_b0u, ivec2(i, j), vec4(u + float(256*1 - (rand1 & 512*1)), 0.0, 0.0, 0.0));
+            imageStore(out_b0v, ivec2(i, j), vec4(v + float(256*1 - (rand2 & 512*1)), 0.0, 0.0, 0.0));
+        //  imageStore(out_b0d, ivec2(i, j), vec4(0.0, 0.0, 0.0, 0.0));
+        }
+    }
+    }
+
+void main()
+{
+    motion(px, py);
+}
+)";
+
+static const char *fast_smoke_diffuse1_source =
+    R"(
+void run_pixel(int x, int y)
+{
+    int k;
+    float t = 0.0002;
+    float a = 0.002;
+    vec4 s = imageLoad(in_b0u, ivec2(x, y));
+    vec4 d1 = imageLoad(in_b1u, ivec2(x - 1, y));
+    vec4 d2 = imageLoad(in_b1u, ivec2(x + 1, y));
+    vec4 d3 = imageLoad(in_b1u, ivec2(x, y - 1));
+    vec4 d4 = imageLoad(in_b1u, ivec2(x, y + 1));
+    float sx = s.x;
+    float du1 = d1.x;
+    float du2 = d2.x;
+    float du3 = d3.x;
+    float du4 = d4.x;
+    float t1 = du1 + du2 + du3 + du4;
+    s = imageLoad(in_b0v, ivec2(x, y));
+    d1 = imageLoad(in_b1v, ivec2(x - 1, y));
+    d2 = imageLoad(in_b1v, ivec2(x + 1, y));
+    d3 = imageLoad(in_b1v, ivec2(x, y - 1));
+    d4 = imageLoad(in_b1v, ivec2(x, y + 1));
+    float sy = s.x;
+    du1 = d1.x;
+    du2 = d2.x;
+    du3 = d3.x;
+    du4 = d4.x;
+    float t2 = du1 + du2 + du3 + du4;
+    imageStore(out_b1u, ivec2(x, y), vec4((sx + a * t1) / (1.0 + 4.0 * a) * 0.9999999999999999999999999999999999999999995, 0.0, 0.0, 0.0));
+    imageStore(out_b1v, ivec2(x, y), vec4((sy + a * t2) / (1.0 + 4.0 * a) * 0.9999999999999999999999999999999999999999995, 0.0, 0.0, 0.0));
+
+
+}
+)";
+
+static const char *fast_smoke_project1_source =
+    R"(
+void run_pixel(int x, int y) {
+    int k, l, s;
+    float h;
+
+    h = 1.0 / float(width);
+//  s = width;
+
+    vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+    vec4 s3 = imageLoad(in_b1v, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b1v, ivec2(x, y + 1));
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float v1 = s3.x;
+    float v2 = s4.x;
+    imageStore(out_b0u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
+    imageStore(out_b0v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
+}
+)";
+
+static const char *fast_smoke_project2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+    int k, l, s;
+    float h;
+
+    h = 1.0 / float(width);
+    s = width;
+
+    vec4 s0 = imageLoad(in_b0v, ivec2(x, y));
+    vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+    vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float u3 = s3.x;
+    float u4 = s4.x;
+
+    imageStore(out_b0u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+})";
+
+static const char *fast_smoke_project3_source =
+    R"(
+void run_pixel(int x, int y)
+{
+    int k, l, s;
+    float h;
+
+    h = 1.0 / float(width);
+    s = width;
+
+    vec4 s0x = imageLoad(in_b1u, ivec2(x, y));
+    vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+    vec4 s0y = imageLoad(in_b1v, ivec2(x, y));
+    vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+    float su = s0x.x;
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float sv = s0y.x;
+    float u3 = s3.x;
+    float u4 = s4.x;
+    imageStore(out_b1u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+    imageStore(out_b1v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+})";
+
+static const char *fast_smoke_advect1_source =
+    R"(
+
+void run_pixel(int x, int y) /* b1.u, b1.v, b1.u, b0.u */
+{
+    int stride;
+    int i, j;
+    float fx, fy;
+    stride = width;
+
+    vec4 sx = imageLoad(in_b1u, ivec2(x, y));
+    vec4 sy = imageLoad(in_b1v, ivec2(x, y));
+    float ix = float(x) - sx.x;
+    float iy = float(y) - sy.x;
+    
+
+    ix = clamp(ix, 0.5, float(width) - 1.5);
+    iy = clamp(iy, 0.5, float(height) - 1.5);
+
+    i = int(ix);
+    j = int(iy);
+    fx = ix - float(i);
+    fy = iy - float(j);
+
+    // Process u component
+    vec4 s0x = imageLoad(in_b1u, ivec2(i, j));
+    vec4 s1x = imageLoad(in_b1u, ivec2(i + 1, j));
+    vec4 s2x = imageLoad(in_b1u, ivec2(i, j + 1));
+    vec4 s3x = imageLoad(in_b1u, ivec2(i + 1, j + 1));
+    float p1 = (s0x.x * (1.0 - fx) + s1x.x * fx) * (1.0 - fy) + (s2x.x * (1.0 - fx) + s3x.x * fx) * fy;
+    imageStore(out_b0u, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+
+    ix = float(x) - sx.x;
+    iy = float(y) - sy.x;
+
+    ix = clamp(ix, 0.5, float(width) - 1.5);
+    iy = clamp(iy, 0.5, float(height) - 1.5);
+    
+    i = int(ix);
+    j = int(iy);
+    fx = ix - float(i);
+    fy = iy - float(j);
+
+    // Process v component
+    vec4 s0y = imageLoad(in_b1v, ivec2(i, j));
+    vec4 s1y = imageLoad(in_b1v, ivec2(i + 1, j));
+    vec4 s2y = imageLoad(in_b1v, ivec2(i, j + 1));
+    vec4 s3y = imageLoad(in_b1v, ivec2(i + 1, j + 1));
+    float p2 = (s0y.x * (1.0 - fx) + s1y.x * fx) * (1.0 - fy) + (s2y.x * (1.0 - fx) + s3y.x * fx) * fy;
+    imageStore(out_b0v, ivec2(x, y), vec4(p2, 0.0, 0.0, 0.0));
+})";
+
+static const char *fast_smoke_project4_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fast_smoke_project5_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fast_smoke_project6_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fast_smoke_diffuse2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *fast_smoke_advect2_source =
+    R"(
+void run_pixel(int x, int y) 
+{
+
+})";
+
+//math from https://inria.hal.science/inria-00596050/document
+static const char *fast_smoke_render_source =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 4) uniform bool ink;
+layout(location = 8) uniform vec4 smoke_color;
+layout(location = 9) uniform vec4 decor_color;
+layout(location = 10) uniform int regionInfo[20];
+
+
+const float K = 1.0;
+const float v = 0.0005; // Viscosity
+const vec2 Step = vec2(0.005, 0.005); // Texture step for resolution
+const vec4 ExternalForces = vec4(-0.0, 0.0, 10.0, 0.0);
+const float dt = 0.2; // Constant small time step
+const float k = 0.1; // Or replace with the appropriate diffusion coefficient value
+
+
+bool IsBoundary(vec2 UV) {
+    // Implement your boundary condition check here
+    return false;
+}
+
+
+void run_pixel(int x, int y)
+{
+
+
+    ivec2 coords = ivec2(x, y);
+    vec2 UV = (vec2(coords) + 0.5) / vec2(imageSize(in_b0d));
+
+
+    float CScale = 1.0 / 2.0;
+    float S = K / dt;
+    
+    vec4 FC = imageLoad(in_b0d, ivec2(x, y));
+    vec4 FR = imageLoad(in_b0d, ivec2(x + 1, y));
+    vec4 FL = imageLoad(in_b0d, ivec2(x - 1, y));
+    vec4 FT = imageLoad(in_b0d, ivec2(x, y + 1));
+    vec4 FD = imageLoad(in_b0d, ivec2(x, y - 1));
+
+
+ mat4 FieldMat = mat4(FR, FL, FT, FD);
+    // du/dx, du/dy
+    vec3 UdX = (FieldMat[0].xyz - FieldMat[1].xyz) * CScale;
+    vec3 UdY = (FieldMat[2].xyz - FieldMat[3].xyz) * CScale;
+    float Udiv = UdX.x + UdY.y;
+    vec2 DdX = vec2(UdX.z, UdY.z);
+    // Solve for density.
+    FC.z -= dt * dot(vec3(DdX, Udiv), FC.xyz);
+    // Related to stability.
+    FC.z = clamp(FC.z, 0.5, 3.0);
+    // Solve for Velocity.
+    vec2 PdX = S * DdX;
+    vec2 Laplacian = vec2(1.0) * dot(vec4(0.0), vec4(FieldMat)) - 4000000.0 * FC.xy;
+    vec2 ViscosityForce = v * Laplacian;
+    // Semi-lagrangian advection.
+    // Assuming you want to change the direction along the x-axis:
+// Adjust the texture coordinates accordingly to change the direction of advection
+
+// Update the texture coordinates for advection
+vec2 Was = UV - dt * FC.xy * Step;
+
+// Modify the texture coordinates based on the desired direction
+// For example, to change the direction along the y-axis:
+// Was.y = UV.y - dt * FC.y * Step.y;
+//Was.x = UV.x + dt * FC.x * Step.x;
+// Convert Was to texture coordinates
+Was = Was * vec2(imageSize(in_b0u));
+
+// Sample the velocity texture using the updated coordinates
+vec2 newVelocity = imageLoad(in_b0u, ivec2(Was)).xy;
+
+// Update FC.xy with the new velocity
+FC.xy = newVelocity;
+
+
+  FC.xy = imageLoad(in_b0u, ivec2(Was)).xy;
+    FC.xy += dt * (ViscosityForce - PdX + ExternalForces.xy);
+
+  // Output
+ //   imageStore(out_tex, coords, FC* 1.0);
+
+// Calculate the density value
+float density = FC.x;
+
+// Define a threshold to determine the blend factor
+float threshold = 0.02;
+
+
+ /// Semi-Lagrangian advection
+vec2 advectionOffset = newVelocity * dt; 
+vec2 advectedCoords = UV - advectionOffset;
+advectedCoords = clamp(advectedCoords, vec2(0.0), vec2(1.0));
+
+// Convert the floating-point texture coordinates to integer indices
+ivec2 texCoords = ivec2(clamp(advectedCoords * vec2(imageSize(in_b0u)), vec2(0.0), vec2(imageSize(in_b0u)) - 1.0));
+
+// Sample the velocity texture using the updated integer indices
+ newVelocity = imageLoad(in_b0u, texCoords).xy;
+
+
+
+
+UdX = (FR.xyz - FL.xyz) * (1.0 / 2.0);
+ UdY = (FT.xyz - FD.xyz) * (1.0 / 2.0);
+Udiv = UdX.x - UdX.y + UdY.x - UdY.y; // Divergence of the velocity field
+
+float laplacian = dot(vec4(1.0), vec4(FC.z, FC.z, FC.z, FC.z)) - 4.0 * FC.z;
+FC.z += dt * k * laplacian;
+
+
+   // FC.xy = newVelocity;
+
+
+    // Calculate the final density value
+    density = FC.x;
+
+
+
+
+vec4 blendedColor = mix(vec4(smoke_color.r,smoke_color.g,smoke_color.b,FC*-10.0), vec4(smoke_color.r,smoke_color.g,smoke_color.b,FC*10.0), smoothstep(0.0, 1.0, density*FC.z*10.0 / threshold));
+
+//vec4 blendedColor = mix(vec4(smoke_color.r,smoke_color.g,smoke_color.b,FC*-10.0), vec4(smoke_color.r,smoke_color.g,smoke_color.b,1.0), smoothstep(0.0, 1.0, density*FC.z / threshold));
+
+
+
+
+
+// Output the blended color
+//imageStore(out_tex, coords, blendedColor);
+
+// Blend the decor color with the blended smoke color
+vec4 finalColor = mix(decor_color, blendedColor, blendedColor.a);
+ 
+
+    // Apply threshold and blend colors
+//    blendedColor = mix(vec4(smoke_color.r, smoke_color.g, smoke_color.b, FC.z * -10.0), vec4(smoke_color.r, smoke_color.g, smoke_color.b, FC.z * 1.0), smoothstep(0.0, 1.0, density / threshold));
+
+  
+
+// Output the final color
+imageStore(out_tex, coords, finalColor);
+})";
+
+
+
+/*///////////////////////////////////////////////
+	  ______  _   ____     ______
+	 |  ____|| | |  __ \  |  ____|
+	 | |__   | | | |__\ | |  |____
+	 |  __|  | | | ___  | |  ____|
+	 | |     | | | |  \ \ |  |____
+	 |_|     |_| |_|  |_| |______|
+
+*////////////////////////////////////////////////
+
+
+static const char *flame_motion_source =
+    R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 1, r32f) uniform writeonly image2D out_b0u;
+layout (binding = 2, r32f) uniform readonly image2D in_b0v;
+layout (binding = 2, r32f) uniform writeonly image2D out_b0v;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (binding = 3, r32f) uniform writeonly image2D out_b0d;
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(location = 1) uniform int title_height;
+layout(location = 2) uniform int border_size;
+layout(location = 3) uniform int px;
+layout(location = 4) uniform int py;
+layout(location = 5) uniform int width;
+layout(location = 6) uniform int height;
+layout(location = 7) uniform int rand1;
+layout(location = 8) uniform int rand2;
+layout(location = 9) uniform int radius;
+
+void motion(int x, int y)
+{
+    int i, i0, i1, j, j0, j1, d = 2;
+
+    if (x - d < 1)
+        i0 = 1;
+    else
+        i0 = x - d;
+    if (i0 + 2 * d > width - 1)
+        i1 = width - 1;
+    else
+        i1 = i0 + 2 * d;
+
+    if (y - d < 1)
+        j0 = 1;
+    else
+        j0 = y - d;
+    if (j0 + 2 * d > height - 1)
+        j1 = height - 1;
+    else
+        j1 = j0 + 2 * d;
+
+    for (i = i0; i < i1; i++)
+    {
+        for (j = j0; j < j1; j++) {
+            if (i < radius || j < radius || i > (width - 1) - radius || j > (height - 1) - radius || (i > border_size && i < (width - 1) - border_size && j > (title_height - 1) && j < (height - 1) - border_size))
+            {
+                continue;
+            }
+            vec4 b0u = imageLoad(in_b0u, ivec2(i, j));
+            vec4 b0v = imageLoad(in_b0u, ivec2(i, j));
+            vec4 b0d = imageLoad(in_b0u, ivec2(i, j));
+            float u = b0u.x;
+            float v = b0v.x;
+            float d = b0d.x;
+            imageStore(out_b0u, ivec2(i, j), vec4(u + float(256*4 - (rand1 & 512*4)), 0.0, 0.0, 0.0));
+            imageStore(out_b0v, ivec2(i, j), vec4(v + float(256*4 - (rand2 & 512*4)), 0.0, 0.0, 0.0));
+        //  imageStore(out_b0d, ivec2(i, j), vec4(0.0, 0.0, 0.0, 0.0));
+        }
+    }
+    }
+
+void main()
+{
+    motion(px, py);
+}
+)";
+
+static const char *flame_diffuse1_source =
+    R"(
+void run_pixel(int x, int y)
+{
+    int k;
+    float t = 0.0002;
+    float a = 0.002;
+    vec4 s = imageLoad(in_b0u, ivec2(x, y));
+    vec4 d1 = imageLoad(in_b1u, ivec2(x - 1, y));
+    vec4 d2 = imageLoad(in_b1u, ivec2(x + 1, y));
+    vec4 d3 = imageLoad(in_b1u, ivec2(x, y - 1));
+    vec4 d4 = imageLoad(in_b1u, ivec2(x, y + 1));
+    float sx = s.x;
+    float du1 = d1.x;
+    float du2 = d2.x;
+    float du3 = d3.x;
+    float du4 = d4.x;
+    float t1 = du1 + du2 + du3 + du4;
+    s = imageLoad(in_b0v, ivec2(x, y));
+    d1 = imageLoad(in_b1v, ivec2(x - 1, y));
+    d2 = imageLoad(in_b1v, ivec2(x + 1, y));
+    d3 = imageLoad(in_b1v, ivec2(x, y - 1));
+    d4 = imageLoad(in_b1v, ivec2(x, y + 1));
+    float sy = s.x;
+    du1 = d1.x;
+    du2 = d2.x;
+    du3 = d3.x;
+    du4 = d4.x;
+    float t2 = du1 + du2 + du3 + du4;
+    imageStore(out_b1u, ivec2(x, y), vec4((sx + a * t1) / (1.0 + 4.0 * a) * 0.9999999999999999999999999999999999999999995, 0.0, 0.0, 0.0));
+    imageStore(out_b1v, ivec2(x, y), vec4((sy + a * t2) / (1.0 + 4.0 * a) * 0.9999999999999999999999999999999999999999995, 0.0, 0.0, 0.0));
+
+
+}
+)";
+
+static const char *flame_project1_source =
+    R"(
+void run_pixel(int x, int y) {
+    int k, l, s;
+    float h;
+
+    h = 1.0 / float(width);
+//  s = width;
+
+    vec4 s1 = imageLoad(in_b1u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b1u, ivec2(x + 1, y));
+    vec4 s3 = imageLoad(in_b1v, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b1v, ivec2(x, y + 1));
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float v1 = s3.x;
+    float v2 = s4.x;
+    imageStore(out_b0u, ivec2(x, y), vec4(0.0, 0.0, 0.0, 0.0));
+    imageStore(out_b0v, ivec2(x, y), vec4(-0.5 * h * (u2 - u1 + v2 - v1), 0.0, 0.0, 0.0));
+}
+)";
+
+static const char *flame_project2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+    int k, l, s;
+    float h;
+
+    h = 1.0 / float(width);
+    s = width;
+
+    vec4 s0 = imageLoad(in_b0v, ivec2(x, y));
+    vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+    vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float u3 = s3.x;
+    float u4 = s4.x;
+
+    imageStore(out_b0u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+})";
+
+static const char *flame_project3_source =
+    R"(
+void run_pixel(int x, int y)
+{
+    int k, l, s;
+    float h;
+
+    h = 1.0 / float(width);
+    s = width;
+
+    vec4 s0x = imageLoad(in_b1u, ivec2(x, y));
+    vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+    vec4 s0y = imageLoad(in_b1v, ivec2(x, y));
+    vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+    float su = s0x.x;
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float sv = s0y.x;
+    float u3 = s3.x;
+    float u4 = s4.x;
+    imageStore(out_b1u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+    imageStore(out_b1v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+})";
+
+static const char *flame_advect1_source =
+    R"(
+
+void run_pixel(int x, int y) /* b1.u, b1.v, b1.u, b0.u */
+{
+    int stride;
+    int i, j;
+    float fx, fy;
+    stride = width;
+
+    vec4 sx = imageLoad(in_b1u, ivec2(x, y));
+    vec4 sy = imageLoad(in_b1v, ivec2(x, y));
+    float ix = float(x) - sx.x;
+    float iy = float(y) - sy.x;
+    
+
+    ix = clamp(ix, 0.5, float(width) - 1.5);
+    iy = clamp(iy, 0.5, float(height) - 1.5);
+
+    i = int(ix);
+    j = int(iy);
+    fx = ix - float(i);
+    fy = iy - float(j);
+
+    // Process u component
+    vec4 s0x = imageLoad(in_b1u, ivec2(i, j));
+    vec4 s1x = imageLoad(in_b1u, ivec2(i + 1, j));
+    vec4 s2x = imageLoad(in_b1u, ivec2(i, j + 1));
+    vec4 s3x = imageLoad(in_b1u, ivec2(i + 1, j + 1));
+    float p1 = (s0x.x * (1.0 - fx) + s1x.x * fx) * (1.0 - fy) + (s2x.x * (1.0 - fx) + s3x.x * fx) * fy;
+    imageStore(out_b0u, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+
+    ix = float(x) - sx.x;
+    iy = float(y) - sy.x;
+
+    ix = clamp(ix, 0.5, float(width) - 1.5);
+    iy = clamp(iy, 0.5, float(height) - 1.5);
+    
+    i = int(ix);
+    j = int(iy);
+    fx = ix - float(i);
+    fy = iy - float(j);
+
+    // Process v component
+    vec4 s0y = imageLoad(in_b1v, ivec2(i, j));
+    vec4 s1y = imageLoad(in_b1v, ivec2(i + 1, j));
+    vec4 s2y = imageLoad(in_b1v, ivec2(i, j + 1));
+    vec4 s3y = imageLoad(in_b1v, ivec2(i + 1, j + 1));
+    float p2 = (s0y.x * (1.0 - fx) + s1y.x * fx) * (1.0 - fy) + (s2y.x * (1.0 - fx) + s3y.x * fx) * fy;
+    imageStore(out_b0v, ivec2(x, y), vec4(p2, 0.0, 0.0, 0.0));
+})";
+
+static const char *flame_project4_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *flame_project5_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *flame_project6_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *flame_diffuse2_source =
+    R"(
+void run_pixel(int x, int y)
+{
+})";
+
+static const char *flame_advect2_source =
+    R"(
+void run_pixel(int x, int y) 
+{
+
+})";
+
+static const char *flame_render_source =
+R"(
+#version 320 es
+
+precision lowp image2D;
+
+layout (binding = 0, rgba32f) uniform writeonly image2D out_tex;
+layout (binding = 1, r32f) uniform readonly image2D in_b0u;
+layout (binding = 3, r32f) uniform readonly image2D in_b0d;
+layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(location = 4) uniform bool ink;
+layout(location = 8) uniform vec4 smoke_color;
+layout(location = 9) uniform vec4 decor_color;
+layout(location = 10) uniform int regionInfo[20];
+
+const float K = 10000.0;
+const float v = 0.0000000000005; // Viscosity
+const vec2 Step = vec2(0.5, 0.5); // Texture step for resolution
+const vec4 ExternalForces = vec4(-0.0, 0.0, 10.0, 0.0);
+const float dt = -0.2; // Constant small time step
+
+bool IsBoundary(vec2 UV) {
+    // Implement your boundary condition check here
+    return false;
+}
+
+float rand(vec2 uv) {
+    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void run_pixel(int x, int y)
+{
+    ivec2 coords = ivec2(x, y);
+
+    // Calculate UV coordinates
+    vec2 UV = (vec2(coords) + 0.5) / vec2(imageSize(in_b0d));
+
+    // Load neighboring pixels
+    vec4 FR = imageLoad(in_b0d, coords + ivec2(1, 0));
+    vec4 FL = imageLoad(in_b0d, coords + ivec2(-1, 0));
+    vec4 FT = imageLoad(in_b0d, coords + ivec2(0, 1));
+    vec4 FD = imageLoad(in_b0d, coords + ivec2(0, -1));
+
+    // Calculate gradients
+    vec3 UdX = (FR.xyz - FL.xyz) * 0.5;
+    vec3 UdY = (FT.xyz - FD.xyz) * 0.5;
+    float Udiv = UdX.x + UdY.y;
+    vec2 DdX = vec2(UdX.z, UdY.z);
+
+    // Update density
+    vec4 FC = imageLoad(in_b0d, coords);
+    FC.z -= dt * dot(vec3(DdX, Udiv), FC.xyz) + K * dot(DdX, DdX) - 5.0; // Updated density equation
+    FC.z = clamp(FC.z, 0.5, 3.0);
+
+    // Update velocity
+    vec2 Was = UV - dt * FC.xy * Step;
+    Was.y = UV.y - dt * FC.y * Step.y;
+    Was.x = UV.x + dt * FC.x * Step.x;
+    Was = Was * vec2(imageSize(in_b0u));
+    vec2 newVelocity = imageLoad(in_b0u, ivec2(Was)).xy;
+    FC.xy = newVelocity;
+    FC.xy += dt * (v * ((FR.x + FL.x + FT.x + FD.x) / 100.0) - DdX );
+
+    // Calculate density value
+    float density = FC.x;
+
+    // Calculate blended color
+    vec4 blendedColor = mix(vec4(0.5 * FC.x, 0.05 * FC.x, -0.05 * FC.x, -10.0 * FC.x), vec4(0.1 * FC.x,0.1 * FC.x,0.5 * FC.x, FC.x), smoothstep(0.0, 1.0, density / 10.02));
+
+    // Blend decor color with smoke color
+//    vec4 finalColor = mix(decor_color, blendedColor, blendedColor.a * -FC.z*10.0);
+    vec4 finalColor = mix(vec4(0.0,0.0,0.0,1.0), blendedColor, blendedColor.a * -FC.z*10.0);
+    // Output the final color
+    imageStore(out_tex, coords, finalColor);
+}
+)";
+
+
+
+
+
+
+/*
+  int stride;
+    int i, j;
+    float fx, fy;
+    stride = width;
+
+    vec4 sx = imageLoad(in_b1u, ivec2(x, y));
+    vec4 sy = imageLoad(in_b1v, ivec2(x, y));
+    float ix = float(x) - sx.x;
+    float iy = float(y) - sy.x;
+    
+
+    ix = clamp(ix, 0.5, float(width) - 1.5);
+    iy = clamp(iy, 0.5, float(height) - 1.5);
+
+    i = int(ix);
+    j = int(iy);
+    fx = ix - float(i);
+    fy = iy - float(j);
+
+    // Process u component
+    vec4 s0x = imageLoad(in_b1u, ivec2(i, j));
+    vec4 s1x = imageLoad(in_b1u, ivec2(i + 1, j));
+    vec4 s2x = imageLoad(in_b1u, ivec2(i, j + 1));
+    vec4 s3x = imageLoad(in_b1u, ivec2(i + 1, j + 1));
+    float p1 = (s0x.x * (1.0 - fx) + s1x.x * fx) * (1.0 - fy) + (s2x.x * (1.0 - fx) + s3x.x * fx) * fy;
+    imageStore(out_b0u, ivec2(x, y), vec4(p1, 0.0, 0.0, 0.0));
+
+    ix = float(x) - sx.x;
+    iy = float(y) - sy.x;
+
+    ix = clamp(ix, 0.5, float(width) - 1.5);
+    iy = clamp(iy, 0.5, float(height) - 1.5);
+    
+    i = int(ix);
+    j = int(iy);
+    fx = ix - float(i);
+    fy = iy - float(j);
+
+    // Process v component
+    vec4 s0y = imageLoad(in_b1v, ivec2(i, j));
+    vec4 s1y = imageLoad(in_b1v, ivec2(i + 1, j));
+    vec4 s2y = imageLoad(in_b1v, ivec2(i, j + 1));
+    vec4 s3y = imageLoad(in_b1v, ivec2(i + 1, j + 1));
+    float p2 = (s0y.x * (1.0 - fx) + s1y.x * fx) * (1.0 - fy) + (s2y.x * (1.0 - fx) + s3y.x * fx) * fy;
+    imageStore(out_b0v, ivec2(x, y), vec4(p2, 0.0, 0.0, 0.0));
+
+    int k, l, s;
+    float h;
+
+    h = 1.0 / float(width);
+    s = width;
+
+    vec4 s0 = imageLoad(in_b0v, ivec2(x, y));
+    vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+    vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float u3 = s3.x;
+    float u4 = s4.x;
+
+    imageStore(out_b0u, ivec2(x, y), vec4((s0.x + u1 + u2 + u3 + u4) / 4.0, 0.0, 0.0, 0.0));
+    
+    vec4 s0x = imageLoad(in_b1u, ivec2(x, y));
+    vec4 s1 = imageLoad(in_b0u, ivec2(x - 1, y));
+    vec4 s2 = imageLoad(in_b0u, ivec2(x + 1, y));
+    vec4 s0y = imageLoad(in_b1v, ivec2(x, y));
+    vec4 s3 = imageLoad(in_b0u, ivec2(x, y - 1));
+    vec4 s4 = imageLoad(in_b0u, ivec2(x, y + 1));
+    float su = s0x.x;
+    float u1 = s1.x;
+    float u2 = s2.x;
+    float sv = s0y.x;
+    float u3 = s3.x;
+    float u4 = s4.x;
+    imageStore(out_b1u, ivec2(x, y), vec4(su - 0.5 * (u2 - u1) / h, 0.0, 0.0, 0.0));
+    imageStore(out_b1v, ivec2(x, y), vec4(sv - 0.5 * (u4 - u3) / h, 0.0, 0.0, 0.0));
+
+    int k;
+    float t = 0.0002;
+    float a = 0.002;
+    vec4 s = imageLoad(in_b0u, ivec2(x, y));
+    vec4 d1 = imageLoad(in_b1u, ivec2(x - 1, y));
+    vec4 d2 = imageLoad(in_b1u, ivec2(x + 1, y));
+    vec4 d3 = imageLoad(in_b1u, ivec2(x, y - 1));
+    vec4 d4 = imageLoad(in_b1u, ivec2(x, y + 1));
+    float sx = s.x;
+    float du1 = d1.x;
+    float du2 = d2.x;
+    float du3 = d3.x;
+    float du4 = d4.x;
+    float t1 = du1 + du2 + du3 + du4;
+    s = imageLoad(in_b0v, ivec2(x, y));
+    d1 = imageLoad(in_b1v, ivec2(x - 1, y));
+    d2 = imageLoad(in_b1v, ivec2(x + 1, y));
+    d3 = imageLoad(in_b1v, ivec2(x, y - 1));
+    d4 = imageLoad(in_b1v, ivec2(x, y + 1));
+    float sy = s.x;
+    du1 = d1.x;
+    du2 = d2.x;
+    du3 = d3.x;
+    du4 = d4.x;
+    float t2 = du1 + du2 + du3 + du4;
+    imageStore(out_b1u, ivec2(x, y), vec4((sx + a * t1) / (1.0 + 4.0 * a) * 0.9999999999999999999999999999999999999999995, 0.0, 0.0, 0.0));
+    imageStore(out_b1v, ivec2(x, y), vec4((sy + a * t2) / (1.0 + 4.0 * a) * 0.9999999999999999999999999999999999999999995, 0.0, 0.0, 0.0));
+*/


### PR DESCRIPTION
Include the addition of a single-pass fragment shader below is the original transcript, I merged the changes from ammen99 experimental repo. All base effects have been transitioned to this fragment shader, with the enhancements of the fire and ice effects. 

Additionally, I have introduced new compute shaders for fast smoke, fumes, and flame with increased performance using less buffers once transitioning over to fragment shaders for render source for each of the new additions we will see extra performance, it is currently upto 30% faster than original smoke implementation in specific scenarios.

Ammen99;
This PR aims to make it possible to optimize most of the effects which can be rendered with a single fragment shader pass. The old pipeline uses 3 passes:

    Compute pass for the effect
    Compute pass for the overlay engine
    Fragment shader pass for rendering

The new render code combines all three together in a single fragment shader pass, allowing us to also make efficient use of GL scissor. By reducing the passes, we also reduce the CPU usage.

The idea of how the shaders work:

    All of them share the same headers and the same uniforms, width, height, current_time
    Each effect needs to provide a function, vec4 effect_color(vec2 pos) which gives the color from the effect.
    Each overlay engine provides a function, vec4 overlay_effect(vec2 pos). It may call effect_color() to get the color of the effect, or set a color on its own. For example the none overlay effect simply returns effect_color(pos).
    The main function is the same for all combinations, it just calls overlay_effect(pos).

The headers, effect, overlay and main function code are simply concatenated together to form a single shader which is then executed.
