### PR TITLE
Make titlebar font customizable, respect text-scaling-factor GSetting

### DIFF
--- a/metadata/pixdecor.xml
+++ b/metadata/pixdecor.xml
@@ -37,6 +37,11 @@
 				<_long>Forces window decoration for windows matching the specified criteria.</_long>
 				<default>none</default>
 			</option>
+			<option name="title_font" type="string">
+				<_short>Title Font</_short>
+				<_long>Font to use for the titlebar. Uses the system font by default or if invalid.</_long>
+				<default></default>
+			</option>
 			<option name="fg_color" type="color">
 				<_short>Color when focused</_short>
 				<_long>Color of the window border when it has focus.</_long>

--- a/src/deco-layout.cpp
+++ b/src/deco-layout.cpp
@@ -59,7 +59,6 @@ decoration_layout_t::decoration_layout_t(const decoration_theme_t& th,
     border_size(th.get_input_size()),
     button_width(th.get_font_height_px() >= LARGE_ICON_THRESHOLD ? 26 : 18),
     button_height(th.get_font_height_px() >= LARGE_ICON_THRESHOLD ? 26 : 18),
-    button_padding((titlebar_size - button_height) / 2),
     theme(th),
     damage_callback(callback)
 {}
@@ -117,6 +116,7 @@ wf::geometry_t decoration_layout_t::create_buttons(int width, int radius)
 
     int per_button = 2 * BUTTON_W_PAD + button_width;
     int border     = theme.get_border_size();
+    int button_padding = (theme.get_title_height() - button_height) / 2;
     wf::geometry_t button_geometry = {
         width - (maximized ? 0 : border),
         button_padding + border / 2 + (radius * 2),

--- a/src/deco-layout.cpp
+++ b/src/deco-layout.cpp
@@ -136,7 +136,7 @@ wf::geometry_t decoration_layout_t::create_buttons(int width, int radius)
 
     return {
         button_geometry.x, maximized ? 0 : border + (radius * 2),
-        total_width, titlebar_size
+        total_width, theme.get_title_height()
     };
 }
 
@@ -153,7 +153,7 @@ void decoration_layout_t::resize(int width, int height)
 
     this->layout_areas.clear();
 
-    if (this->titlebar_size > 0)
+    if (this->theme.get_title_height() > 0)
     {
         auto button_geometry_expanded = create_buttons(width - (radius * 2), radius);
 
@@ -168,7 +168,7 @@ void decoration_layout_t::resize(int width, int height)
             /* Up to the button, but subtract the padding to the left of the
              * title and the padding between title and button */
             button_geometry_expanded.x - border,
-            titlebar_size + (maximized ? 0 : border / 2 + 1),
+            theme.get_title_height() + (maximized ? 0 : border / 2 + 1),
         };
         this->layout_areas.push_back(std::make_unique<decoration_area_t>(
             DECORATION_AREA_TITLE, title_geometry));

--- a/src/deco-layout.hpp
+++ b/src/deco-layout.hpp
@@ -163,7 +163,6 @@ class decoration_layout_t
     const int border_size;
     const int button_width;
     const int button_height;
-    const int button_padding;
     const decoration_theme_t& theme;
     bool maximized;
 

--- a/src/deco-subsurface.hpp
+++ b/src/deco-subsurface.hpp
@@ -24,6 +24,7 @@ class simple_decorator_t : public wf::custom_data_t
   public:
     void update_colors();
     void effect_updated();
+    void recreate_frame();
     void update_decoration_size();
     simple_decorator_t(wayfire_toplevel_view view);
     ~simple_decorator_t();

--- a/src/deco-theme.cpp
+++ b/src/deco-theme.cpp
@@ -44,6 +44,10 @@ void decoration_theme_t::update_colors(void)
     bg_text = wf::color_t(bg_text_color);
 }
 
+/**
+ * @return A PangoFontDescription representing either a provided font from
+ *  the Title Font option or the system font, scaled by the text-scaling-factor GSetting.
+ */
 PangoFontDescription *create_font_description()
 {
     GSettings *gs = g_settings_new("org.gnome.desktop.interface");
@@ -102,6 +106,11 @@ PangoFontDescription *create_font_description()
     return font_desc;
 }
 
+/**
+ * @return A PangoFontDescription from create_font_description(),
+ *  originating from a global, internally managed instance, freeing the data upon exit.
+ *  It will also be updated with changes to the Title Font option.
+ */
 PangoFontDescription *get_font_description()
 {
     static std::unique_ptr<PangoFontDescription, decltype(&pango_font_description_free)> font_desc(

--- a/src/deco-theme.cpp
+++ b/src/deco-theme.cpp
@@ -2,6 +2,7 @@
 #include <wayfire/core.hpp>
 #include <wayfire/opengl.hpp>
 #include <map>
+#include <mutex>
 #include <stdlib.h>
 
 namespace wf
@@ -13,6 +14,7 @@ wf::option_wrapper_t<int> title_text_align{"pixdecor/title_text_align"};
 wf::option_wrapper_t<bool> titlebar{"pixdecor/titlebar"};
 wf::option_wrapper_t<bool> maximized_borders{"pixdecor/maximized_borders"};
 wf::option_wrapper_t<bool> maximized_shadows{"pixdecor/maximized_shadows"};
+wf::option_wrapper_t<std::string> title_font{"pixdecor/title_font"};
 wf::option_wrapper_t<wf::color_t> fg_color{"pixdecor/fg_color"};
 wf::option_wrapper_t<wf::color_t> bg_color{"pixdecor/bg_color"};
 wf::option_wrapper_t<wf::color_t> fg_text_color{"pixdecor/fg_text_color"};
@@ -42,30 +44,94 @@ void decoration_theme_t::update_colors(void)
     bg_text = wf::color_t(bg_text_color);
 }
 
+PangoFontDescription *create_font_description()
+{
+    GSettings *gs = g_settings_new("org.gnome.desktop.interface");
+
+    std::string title_font_val(title_font);
+    bool using_system_font{};
+
+    if (title_font_val.empty())
+    {
+        char *font = g_settings_get_string(gs, "font-name");
+        title_font_val = font;
+        using_system_font = true;
+        g_free(font);
+    }
+
+    PangoFontDescription *font_desc = pango_font_description_from_string(title_font_val.c_str());
+    int font_size = pango_font_description_get_size(font_desc);
+    bool font_size_absolute;
+
+    // font size will be 0 if nothing is specified - grab from system font if this is the case
+    // if the font is the system font, then just pray it works
+    if (!font_size && !using_system_font)
+    {
+        char *font = g_settings_get_string(gs, "font-name");
+        PangoFontDescription *sys_font_desc = pango_font_description_from_string(font);
+
+        font_size = pango_font_description_get_size(sys_font_desc);
+        font_size_absolute = pango_font_description_get_size_is_absolute(sys_font_desc);
+
+        pango_font_description_free(sys_font_desc);
+        g_free(font);
+    } else
+    {
+        font_size_absolute = pango_font_description_get_size_is_absolute(font_desc);
+    }
+
+    // scale the font size if we got it by text-scaling-factor
+    if (font_size)
+    {
+        double scaling_factor = g_settings_get_double(gs, "text-scaling-factor");
+        if (!scaling_factor) // should default to 1.0, but better safe than sorry
+        {
+            scaling_factor = 1.0;
+        }
+
+        if (font_size_absolute)
+        {
+            pango_font_description_set_absolute_size(font_desc, font_size * scaling_factor);
+        } else
+        {
+            pango_font_description_set_size(font_desc, font_size * scaling_factor);
+        }
+    }
+
+    g_object_unref(gs);
+    return font_desc;
+}
+
+PangoFontDescription *get_font_description()
+{
+    static std::unique_ptr<PangoFontDescription, decltype(&pango_font_description_free)> font_desc(
+        create_font_description(), &pango_font_description_free);
+
+    static std::once_flag once_flag;
+    std::call_once(once_flag, [] {
+        title_font.set_callback([] {
+            font_desc.reset(create_font_description());
+        });
+    });
+
+    return font_desc.get();
+}
+
 /** @return The available height for displaying the title */
 int decoration_theme_t::get_font_height_px() const
 {
-    static int font_sz = -1;
-    if (font_sz > 0)
-    {
-        return font_sz;
-    }
-
-    char *font = g_settings_get_string(gs, "font-name");
-
-    PangoFontDescription *font_desc = pango_font_description_from_string(font);
+    PangoFontDescription *font_desc = get_font_description();
     int font_height = pango_font_description_get_size(font_desc);
-    g_free(font);
+
     if (!pango_font_description_get_size_is_absolute(font_desc))
     {
         font_height *= 4;
         font_height /= 3;
     }
 
-    pango_font_description_free(font_desc);
-
-    return (font_sz = font_height / PANGO_SCALE);
+    return font_height / PANGO_SCALE;
 }
+
 
 int decoration_theme_t::get_title_height() const
 {
@@ -146,11 +212,10 @@ cairo_surface_t*decoration_theme_t::render_text(std::string text,
 
     PangoFontDescription *font_desc;
     PangoLayout *layout;
-    char *font = g_settings_get_string(gs, "font-name");
     int x, w, h;
 
     // render text
-    font_desc = pango_font_description_from_string(font);
+    font_desc = get_font_description();
 
     layout = pango_cairo_create_layout(cr);
     pango_layout_set_font_description(layout, font_desc);
@@ -179,10 +244,8 @@ cairo_surface_t*decoration_theme_t::render_text(std::string text,
 
     cairo_translate(cr, x, (height - h) / 2);
     pango_cairo_show_layout(cr, layout);
-    pango_font_description_free(font_desc);
     g_object_unref(layout);
     cairo_destroy(cr);
-    g_free(font);
 
     return surface;
 }

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -45,6 +45,7 @@ int handle_theme_updated(int fd, uint32_t mask, void *data)
 class wayfire_pixdecor : public wf::plugin_interface_t
 {
     wf::option_wrapper_t<int> border_size{"pixdecor/border_size"};
+    wf::option_wrapper_t<std::string> title_font{"pixdecor/title_font"};
     wf::option_wrapper_t<int> title_text_align{"pixdecor/title_text_align"};
     wf::option_wrapper_t<bool> titlebar{"pixdecor/titlebar"};
     wf::option_wrapper_t<bool> maximized_borders{"pixdecor/maximized_borders"};
@@ -407,6 +408,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
                 view->damage();
             }
         });
+        title_font.set_callback([=] {recreate_frames();});
         shadow_radius.set_callback([=]
         {
             option_changed_cb(false, (std::string(overlay_engine) == "rounded_corners"));
@@ -523,6 +525,25 @@ class wayfire_pixdecor : public wf::plugin_interface_t
         inotify_rm_watch(inotify_fd, wd_cfg_file);
         inotify_rm_watch(inotify_fd, wd_cfg_dir);
         close(inotify_fd);
+    }
+
+    void recreate_frames()
+    {
+        for (auto& view : wf::get_core().get_all_views())
+        {
+            auto toplevel = wf::toplevel_cast(view);
+            if (!toplevel)
+            {
+                continue;
+            }
+            auto deco = toplevel->toplevel()->get_data<wf::simple_decorator_t>();
+            if (!deco)
+            {
+                continue;
+            }
+
+            deco->recreate_frame();
+        }
     }
 
     void option_changed_cb(bool resize_decorations, bool recreate_decorations)


### PR DESCRIPTION
Adds an option to provide a font for the titlebar, in standard font description format (ie. "Roboto 11"). Will fall back to the system font if invalid or empty.

Additionally, the titlebar's text is now scaled by the text-scaling-factor GSetting. This setting is respected pretty globally, including in titlebars of other compositors like KDE and LabWC (I don't remember if Wayfire's default titlebar does).

In my testing, I have found 2 minor issues, both of which technically existed before this PR and may or may not be worth changing:
- Font changes are not applied immediately upon the option being saved - a window has to be interacted with for its titlebar's font to change. This is due to [an optimization made here](https://github.com/soreau/pixdecor/blob/18779dd970c703d3437173ee7f640aa210ec69ea/src/deco-subsurface.cpp#L66-L70). Forcing a redraw of the on-screen titlebars in the option's callback could be a way to address this, if it's possible.
- Titlebar rendering breaks with excessively large or small font sizes: see [here](https://cdn.imgchest.com/files/7pjcqn6odb7.png) and [here](https://cdn.imgchest.com/files/ye3c2vb38z4.png).