### PR TITLE
Fix namespaces so pixdecor doesn't clash with default decoration plugin

### DIFF
--- a/src/deco-button.cpp
+++ b/src/deco-button.cpp
@@ -12,7 +12,7 @@ namespace wf
 {
 namespace pixdecor
 {
-button_t::button_t(const decoration_theme_t& t, std::function<void()> damage) :
+button_t::button_t(pixdecor_theme_t& t, std::function<void()> damage) :
     theme(t), damage_callback(damage)
 {}
 
@@ -86,7 +86,7 @@ void button_t::render(const wf::render_target_t& fb, wf::geometry_t geometry, co
 
 wf::dimensions_t button_t::update_texture()
 {
-    decoration_theme_t::button_state_t state = {
+    pixdecor_theme_t::button_state_t state = {
         .width  = 1.0 * (theme.get_font_height_px() >= LARGE_ICON_THRESHOLD ? 26 : 18),
         .height = 1.0 * (theme.get_font_height_px() >= LARGE_ICON_THRESHOLD ? 26 : 18),
         .border = 1.0,

--- a/src/deco-button.hpp
+++ b/src/deco-button.hpp
@@ -15,7 +15,7 @@ namespace wf
 {
 namespace pixdecor
 {
-class decoration_theme_t;
+class pixdecor_theme_t;
 
 enum button_type_t
 {
@@ -33,7 +33,7 @@ class button_t
      * @param damage_callback   A callback to execute when the button needs a
      * repaint. Damage won't be reported while render() is being called.
      */
-    button_t(const decoration_theme_t& theme,
+    button_t(pixdecor_theme_t& theme,
         std::function<void()> damage_callback);
 
     /**
@@ -68,7 +68,7 @@ class button_t
     void render(const wf::render_target_t& fb, wf::geometry_t geometry,
         const wf::region_t& scissor);
 
-    const decoration_theme_t& theme;
+    pixdecor_theme_t& theme;
     std::function<void()> damage_callback;
 
   private:

--- a/src/deco-layout.cpp
+++ b/src/deco-layout.cpp
@@ -26,7 +26,7 @@ decoration_area_t::decoration_area_t(decoration_area_type_t type, wf::geometry_t
  */
 decoration_area_t::decoration_area_t(wf::geometry_t g,
     std::function<void(wlr_box)> damage_callback,
-    const decoration_theme_t& theme)
+    pixdecor_theme_t& theme)
 {
     this->type     = DECORATION_AREA_BUTTON;
     this->geometry = g;
@@ -64,7 +64,7 @@ decoration_area_type_t decoration_area_t::get_type() const
     return type;
 }
 
-decoration_layout_t::decoration_layout_t(const decoration_theme_t& th,
+pixdecor_layout_t::pixdecor_layout_t(pixdecor_theme_t& th,
     std::function<void(wlr_box)> callback) :
 
     titlebar_size(th.get_title_height()),
@@ -73,12 +73,12 @@ decoration_layout_t::decoration_layout_t(const decoration_theme_t& th,
     damage_callback(callback)
 {}
 
-decoration_layout_t::~decoration_layout_t()
+pixdecor_layout_t::~pixdecor_layout_t()
 {
     this->layout_areas.clear();
 }
 
-wf::geometry_t decoration_layout_t::create_buttons(int width, int radius)
+wf::geometry_t pixdecor_layout_t::create_buttons(int width, int radius)
 {
     // read the string from settings; start at the colon and replace commas with spaces
     wf::option_wrapper_t<int> button_spacing{"pixdecor/button_spacing"};
@@ -158,7 +158,7 @@ wf::geometry_t decoration_layout_t::create_buttons(int width, int radius)
 }
 
 /** Regenerate layout using the new size */
-void decoration_layout_t::resize(int width, int height)
+void pixdecor_layout_t::resize(int width, int height)
 {
     wf::option_wrapper_t<int> shadow_radius{"pixdecor/shadow_radius"};
     wf::option_wrapper_t<std::string> overlay_engine{"pixdecor/overlay_engine"};
@@ -258,7 +258,7 @@ void decoration_layout_t::resize(int width, int height)
  * @return The decoration areas which need to be rendered, in top to bottom
  *  order.
  */
-std::vector<nonstd::observer_ptr<decoration_area_t>> decoration_layout_t::get_renderable_areas()
+std::vector<nonstd::observer_ptr<decoration_area_t>> pixdecor_layout_t::get_renderable_areas()
 {
     std::vector<nonstd::observer_ptr<decoration_area_t>> renderable;
     for (auto& area : layout_areas)
@@ -272,7 +272,7 @@ std::vector<nonstd::observer_ptr<decoration_area_t>> decoration_layout_t::get_re
     return renderable;
 }
 
-wf::region_t decoration_layout_t::calculate_region() const
+wf::region_t pixdecor_layout_t::calculate_region() const
 {
     wf::region_t r{};
     for (auto& area : layout_areas)
@@ -309,13 +309,13 @@ wf::region_t decoration_layout_t::calculate_region() const
     return r;
 }
 
-wf::region_t decoration_layout_t::limit_region(wf::region_t & region) const
+wf::region_t pixdecor_layout_t::limit_region(wf::region_t & region) const
 {
     wf::region_t out = region & this->cached_titlebar;
     return out;
 }
 
-void decoration_layout_t::unset_hover(wf::point_t position)
+void pixdecor_layout_t::unset_hover(wf::point_t position)
 {
     auto area = find_area_at(position);
     if (area && (area->get_type() == DECORATION_AREA_BUTTON))
@@ -325,7 +325,7 @@ void decoration_layout_t::unset_hover(wf::point_t position)
 }
 
 /** Handle motion event to (x, y) relative to the decoration */
-decoration_layout_t::action_response_t decoration_layout_t::handle_motion(
+pixdecor_layout_t::action_response_t pixdecor_layout_t::handle_motion(
     int x, int y)
 {
     auto previous_area = find_area_at(current_input);
@@ -361,7 +361,7 @@ decoration_layout_t::action_response_t decoration_layout_t::handle_motion(
  * @return The action which needs to be carried out in response to this
  *  event.
  * */
-decoration_layout_t::action_response_t decoration_layout_t::handle_press_event(
+pixdecor_layout_t::action_response_t pixdecor_layout_t::handle_press_event(
     bool pressed)
 {
     if (pressed)
@@ -428,7 +428,7 @@ decoration_layout_t::action_response_t decoration_layout_t::handle_press_event(
     return {DECORATION_ACTION_NONE, 0};
 }
 
-decoration_layout_t::action_response_t decoration_layout_t::handle_axis_event(
+pixdecor_layout_t::action_response_t pixdecor_layout_t::handle_axis_event(
     int delta)
 {
     if (delta < 0)
@@ -444,7 +444,7 @@ decoration_layout_t::action_response_t decoration_layout_t::handle_axis_event(
  * Find the layout area at the given coordinates, if any
  * @return The layout area or null on failure
  */
-nonstd::observer_ptr<decoration_area_t> decoration_layout_t::find_area_at(
+nonstd::observer_ptr<decoration_area_t> pixdecor_layout_t::find_area_at(
     wf::point_t point)
 {
     for (auto& area : this->layout_areas)
@@ -507,7 +507,7 @@ nonstd::observer_ptr<decoration_area_t> decoration_layout_t::find_area_at(
 }
 
 /** Calculate resize edges based on @current_input */
-uint32_t decoration_layout_t::calculate_resize_edges() const
+uint32_t pixdecor_layout_t::calculate_resize_edges() const
 {
     wf::option_wrapper_t<int> shadow_radius{"pixdecor/shadow_radius"};
     wf::option_wrapper_t<std::string> overlay_engine{"pixdecor/overlay_engine"};
@@ -553,7 +553,7 @@ uint32_t decoration_layout_t::calculate_resize_edges() const
 }
 
 /** Update the cursor based on @current_input */
-void decoration_layout_t::update_cursor()
+void pixdecor_layout_t::update_cursor()
 {
     uint32_t edges = calculate_resize_edges();
     auto area = find_area_at(this->current_input);
@@ -568,12 +568,12 @@ void decoration_layout_t::update_cursor()
     wf::get_core().set_cursor(cursor_name);
 }
 
-void decoration_layout_t::set_maximize(bool state)
+void pixdecor_layout_t::set_maximize(bool state)
 {
     maximized = state;
 }
 
-void decoration_layout_t::handle_focus_lost()
+void pixdecor_layout_t::handle_focus_lost()
 {
     if (is_grabbed)
     {

--- a/src/deco-layout.hpp
+++ b/src/deco-layout.hpp
@@ -48,7 +48,7 @@ struct decoration_area_t
      */
     decoration_area_t(wf::geometry_t g,
         std::function<void(wlr_box)> damage_callback,
-        const decoration_theme_t& theme);
+        pixdecor_theme_t& theme);
 
     /** @return The geometry of the decoration area, relative to the layout */
     wf::geometry_t get_geometry() const;
@@ -88,14 +88,14 @@ enum decoration_layout_action_t
     DECORATION_ACTION_UNSHADE         = 7,
 };
 
-class decoration_theme_t;
+class pixdecor_theme_t;
 /**
  * Manages the layout of the decorations, i.e positioning of the title,
  * buttons, etc.
  *
  * Also dispatches the input events to the appropriate place.
  */
-class decoration_layout_t
+class pixdecor_layout_t
 {
   public:
     /**
@@ -105,9 +105,9 @@ class decoration_layout_t
      * @param damage_callback The function to be called when a part of the
      * layout needs a repaint.
      */
-    decoration_layout_t(const decoration_theme_t& theme,
+    pixdecor_layout_t(pixdecor_theme_t& theme,
         std::function<void(wlr_box)> damage_callback);
-    ~decoration_layout_t();
+    ~pixdecor_layout_t();
 
     /** Regenerate layout using the new size */
     void resize(int width, int height);
@@ -163,7 +163,7 @@ class decoration_layout_t
   private:
     const int titlebar_size;
     const int border_size;
-    const decoration_theme_t& theme;
+    pixdecor_theme_t& theme;
     bool maximized;
 
     std::function<void(wlr_box)> damage_callback;

--- a/src/deco-subsurface.cpp
+++ b/src/deco-subsurface.cpp
@@ -31,18 +31,22 @@
 #include <cairo.h>
 #include "shade.hpp"
 
-wf::option_wrapper_t<std::string> overlay_engine{"pixdecor/overlay_engine"};
-wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
+
+namespace wf
+{
+namespace pixdecor
+{
 wf::option_wrapper_t<wf::color_t> effect_color{"pixdecor/effect_color"};
 wf::option_wrapper_t<int> shadow_radius{"pixdecor/shadow_radius"};
 wf::option_wrapper_t<bool> titlebar_opt{"pixdecor/titlebar"};
-wf::option_wrapper_t<bool> maximized_borders{"pixdecor/maximized_borders"};
-wf::option_wrapper_t<bool> maximized_shadows{"pixdecor/maximized_shadows"};
 wf::option_wrapper_t<int> csd_titlebar_height{"pixdecor/csd_titlebar_height"};
 wf::option_wrapper_t<bool> enable_shade{"pixdecor/enable_shade"};
 wf::option_wrapper_t<std::string> title_font{"pixdecor/title_font"};
+wf::option_wrapper_t<std::string> overlay_engine{"pixdecor/overlay_engine"};
+wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
+wf::option_wrapper_t<bool> maximized_borders{"pixdecor/maximized_borders"};
+wf::option_wrapper_t<bool> maximized_shadows{"pixdecor/maximized_shadows"};
 wf::option_wrapper_t<int> title_text_align{"pixdecor/title_text_align"};
-
 
 class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_interaction_t,
     public wf::touch_interaction_t
@@ -93,8 +97,8 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
     } title_texture;
 
   public:
-    wf::pixdecor::decoration_theme_t theme;
-    wf::pixdecor::decoration_layout_t layout;
+    pixdecor_theme_t theme;
+    pixdecor_layout_t layout;
     wf::region_t cached_region;
 
     wf::dimensions_t size;
@@ -181,7 +185,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         int buttons_width = 0;
         for (auto item : renderables)
         {
-            if (item->get_type() != wf::pixdecor::DECORATION_AREA_TITLE)
+            if (item->get_type() != DECORATION_AREA_TITLE)
             {
                 buttons_width += item->get_geometry().width;
             }
@@ -192,7 +196,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
             (!maximized || maximized_shadows)) ? int(shadow_radius) * 2 : 0);
         for (auto item : renderables)
         {
-            if (item->get_type() == wf::pixdecor::DECORATION_AREA_TITLE)
+            if (item->get_type() == DECORATION_AREA_TITLE)
             {
                 render_title(fb, region,
                     item->get_geometry() + offset, size.width - border * 2, title_border, buttons_width);
@@ -279,10 +283,10 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
             if (!our_damage.empty())
             {
                 instructions.push_back(wf::scene::render_instruction_t{
-                    .instance = this,
-                    .target   = target,
-                    .damage   = std::move(our_damage),
-                });
+                            .instance = this,
+                            .target   = target,
+                            .damage   = std::move(our_damage),
+                        });
             }
         }
 
@@ -376,17 +380,17 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         }
     }
 
-    std::shared_ptr<wf::pixdecor::pixdecor_shade> ensure_transformer(wayfire_view view, int titlebar_height)
+    std::shared_ptr<pixdecor_shade> ensure_transformer(wayfire_view view, int titlebar_height)
     {
         auto tmgr = view->get_transformed_node();
-        if (auto tr = tmgr->get_transformer<wf::pixdecor::pixdecor_shade>(shade_transformer_name))
+        if (auto tr = tmgr->get_transformer<pixdecor_shade>(shade_transformer_name))
         {
             return tr;
         }
 
-        auto node = std::make_shared<wf::pixdecor::pixdecor_shade>(view, titlebar_height);
+        auto node = std::make_shared<pixdecor_shade>(view, titlebar_height);
         tmgr->add_transformer(node, wf::TRANSFORMER_2D, shade_transformer_name);
-        auto tr = tmgr->get_transformer<wf::pixdecor::pixdecor_shade>(shade_transformer_name);
+        auto tr = tmgr->get_transformer<pixdecor_shade>(shade_transformer_name);
 
         return tr;
     }
@@ -409,7 +413,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         } else
         {
             if (auto tr =
-                    view->get_transformed_node()->get_transformer<wf::pixdecor::pixdecor_shade>(
+                    view->get_transformed_node()->get_transformer<pixdecor_shade>(
                         shade_transformer_name))
             {
                 tr->set_titlebar_height(titlebar_height);
@@ -418,22 +422,22 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         }
     }
 
-    void handle_action(wf::pixdecor::decoration_layout_t::action_response_t action)
+    void handle_action(pixdecor_layout_t::action_response_t action)
     {
         if (auto view = _view.lock())
         {
             switch (action.action)
             {
-              case wf::pixdecor::DECORATION_ACTION_MOVE:
+              case DECORATION_ACTION_MOVE:
                 return wf::get_core().default_wm->move_request(view);
 
-              case wf::pixdecor::DECORATION_ACTION_RESIZE:
+              case DECORATION_ACTION_RESIZE:
                 return wf::get_core().default_wm->resize_request(view, action.edges);
 
-              case wf::pixdecor::DECORATION_ACTION_CLOSE:
+              case DECORATION_ACTION_CLOSE:
                 return view->close();
 
-              case wf::pixdecor::DECORATION_ACTION_TOGGLE_MAXIMIZE:
+              case DECORATION_ACTION_TOGGLE_MAXIMIZE:
                 if (view->pending_tiled_edges())
                 {
                     return wf::get_core().default_wm->tile_request(view, 0);
@@ -444,15 +448,15 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
 
                 break;
 
-              case wf::pixdecor::DECORATION_ACTION_SHADE:
+              case DECORATION_ACTION_SHADE:
                 init_shade(view, true, current_titlebar);
                 break;
 
-              case wf::pixdecor::DECORATION_ACTION_UNSHADE:
+              case DECORATION_ACTION_UNSHADE:
                 init_shade(view, false, current_titlebar);
                 break;
 
-              case wf::pixdecor::DECORATION_ACTION_MINIMIZE:
+              case DECORATION_ACTION_MINIMIZE:
                 return wf::get_core().default_wm->minimize_request(view, true);
                 break;
 
@@ -535,7 +539,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
             }
 
             if (auto tr =
-                    view->get_transformed_node()->get_transformer<wf::pixdecor::pixdecor_shade>(
+                    view->get_transformed_node()->get_transformer<pixdecor_shade>(
                         shade_transformer_name))
             {
                 tr->set_titlebar_height(current_titlebar);
@@ -546,7 +550,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
     }
 };
 
-wf::simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
+simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
 {
     this->view = view;
     this->shadow_thickness = 0;
@@ -586,38 +590,38 @@ wf::simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
     };
 }
 
-wf::simple_decorator_t::~simple_decorator_t()
+simple_decorator_t::~simple_decorator_t()
 {
     wf::scene::remove_child(deco);
     deco.reset();
 }
 
-int wf::simple_decorator_t::get_titlebar_height()
+int simple_decorator_t::get_titlebar_height()
 {
     return deco->current_titlebar;
 }
 
-void wf::simple_decorator_t::recreate_frame()
+void simple_decorator_t::recreate_frame()
 {
     deco->recreate_frame();
 }
 
-void wf::simple_decorator_t::update_decoration_size()
+void simple_decorator_t::update_decoration_size()
 {
     deco->update_decoration_size();
 }
 
-void wf::simple_decorator_t::update_colors()
+void simple_decorator_t::update_colors()
 {
     deco->theme.update_colors();
 }
 
-void wf::simple_decorator_t::effect_updated()
+void simple_decorator_t::effect_updated()
 {
     deco->theme.smoke.effect_updated();
 }
 
-wf::decoration_margins_t wf::simple_decorator_t::get_margins(const wf::toplevel_state_t& state)
+wf::decoration_margins_t simple_decorator_t::get_margins(const wf::toplevel_state_t& state)
 {
     if (state.fullscreen)
     {
@@ -648,7 +652,7 @@ wf::decoration_margins_t wf::simple_decorator_t::get_margins(const wf::toplevel_
 
     double shade_progress = 0.0;
     if (auto tr =
-            view->get_transformed_node()->get_transformer<wf::pixdecor::pixdecor_shade>(
+            view->get_transformed_node()->get_transformer<pixdecor_shade>(
                 shade_transformer_name))
     {
         tr->set_titlebar_height(titlebar);
@@ -678,7 +682,7 @@ wf::decoration_margins_t wf::simple_decorator_t::get_margins(const wf::toplevel_
     };
 }
 
-void wf::simple_decorator_t::update_animation()
+void simple_decorator_t::update_animation()
 {
     auto margins = get_margins(view->toplevel()->current());
     auto bbox    = deco->get_bounding_box();
@@ -689,4 +693,6 @@ void wf::simple_decorator_t::update_animation()
     region |= wlr_box{bbox.x, bbox.y + bbox.height - margins.bottom, bbox.width, margins.bottom};
     region |= wlr_box{bbox.x + bbox.width - margins.right, bbox.y, margins.right, bbox.height};
     wf::scene::damage_node(deco, region);
+}
+}
 }

--- a/src/deco-subsurface.hpp
+++ b/src/deco-subsurface.hpp
@@ -25,9 +25,11 @@ class wf_shadow_margin_t : public wf::custom_data_t
     wf::decoration_margins_t margins = {0, 0, 0, 0};
 };
 
-class simple_decoration_node_t;
 namespace wf
 {
+namespace pixdecor
+{
+class simple_decoration_node_t;
 /**
  * A decorator object attached as custom data to a toplevel object.
  */
@@ -53,6 +55,7 @@ class simple_decorator_t : public wf::custom_data_t
     void update_animation();
     int shadow_thickness;
 };
+}
 }
 
 #endif /* end of include guard: DECO_SUBSURFACE_HPP */

--- a/src/deco-theme.hpp
+++ b/src/deco-theme.hpp
@@ -16,23 +16,31 @@ namespace pixdecor
  * A  class which manages the outlook of decorations.
  * It is responsible for determining the background colors, sizes, etc.
  */
-class decoration_theme_t
+class pixdecor_theme_t
 {
   public:
+    wf::option_wrapper_t<std::string> title_font{"pixdecor/title_font"};
+    wf::option_wrapper_t<std::string> overlay_engine{"pixdecor/overlay_engine"};
+    wf::option_wrapper_t<std::string> effect_type{"pixdecor/effect_type"};
+    wf::option_wrapper_t<bool> maximized_borders{"pixdecor/maximized_borders"};
+    wf::option_wrapper_t<bool> maximized_shadows{"pixdecor/maximized_shadows"};
+    wf::option_wrapper_t<int> title_text_align{"pixdecor/title_text_align"};
     /** Create a new theme with the default parameters */
-    decoration_theme_t();
-    ~decoration_theme_t();
+    pixdecor_theme_t();
+    ~pixdecor_theme_t();
 
     /** @return The height of the system font in pixels */
-    int get_font_height_px() const;
+    int get_font_height_px();
     /** @return The available height for displaying the title */
-    int get_title_height() const;
+    int get_title_height();
     /** @return The available border for rendering */
     int get_border_size() const;
     /** @return The available border for resizing */
     int get_input_size() const;
     /** @return The decoration color */
     wf::color_t get_decor_color(bool active) const;
+    PangoFontDescription *create_font_description();
+    PangoFontDescription *get_font_description();
 
     void update_colors(void);
 
@@ -52,7 +60,7 @@ class decoration_theme_t
      * The caller is responsible for freeing the memory afterwards.
      */
     cairo_surface_t *render_text(std::string text, int width, int height, int t_width, int border,
-        int buttons_width, bool active) const;
+        int buttons_width, bool active);
 
     struct button_state_t
     {

--- a/src/decoration.cpp
+++ b/src/decoration.cpp
@@ -22,6 +22,10 @@
 #include <wayfire/plugins/ipc/ipc-activator.hpp>
 #include "shade.hpp"
 
+namespace wf
+{
+namespace pixdecor
+{
 int handle_theme_updated(int fd, uint32_t mask, void *data)
 {
     int bufsz = sizeof(inotify_event) + NAME_MAX + 1;
@@ -97,7 +101,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             {
                 // First check whether the toplevel already has decoration
                 // In that case, we should just set the correct margins
-                if (auto deco = toplevel->get_data<wf::simple_decorator_t>())
+                if (auto deco = toplevel->get_data<simple_decorator_t>())
                 {
                     deco->update_decoration_size();
                     toplevel->pending().margins = deco->get_margins(toplevel->pending());
@@ -116,7 +120,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
                 wf::dassert(view != nullptr, "Mapping a toplevel means there must be a corresponding view!");
                 if (should_decorate_view(view))
                 {
-                    if (auto deco = toplevel->get_data<wf::simple_decorator_t>())
+                    if (auto deco = toplevel->get_data<simple_decorator_t>())
                     {
                         deco->update_decoration_size();
                     }
@@ -189,17 +193,17 @@ class wayfire_pixdecor : public wf::plugin_interface_t
         }
     }
 
-    std::shared_ptr<wf::pixdecor::pixdecor_shade> ensure_transformer(wayfire_view view, int titlebar_height)
+    std::shared_ptr<pixdecor_shade> ensure_transformer(wayfire_view view, int titlebar_height)
     {
         auto tmgr = view->get_transformed_node();
-        if (auto tr = tmgr->get_transformer<wf::pixdecor::pixdecor_shade>(shade_transformer_name))
+        if (auto tr = tmgr->get_transformer<pixdecor_shade>(shade_transformer_name))
         {
             return tr;
         }
 
-        auto node = std::make_shared<wf::pixdecor::pixdecor_shade>(view, titlebar_height);
+        auto node = std::make_shared<pixdecor_shade>(view, titlebar_height);
         tmgr->add_transformer(node, wf::TRANSFORMER_2D, shade_transformer_name);
-        auto tr = tmgr->get_transformer<wf::pixdecor::pixdecor_shade>(shade_transformer_name);
+        auto tr = tmgr->get_transformer<pixdecor_shade>(shade_transformer_name);
 
         return tr;
     }
@@ -222,7 +226,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
         } else
         {
             if (auto tr =
-                    view->get_transformed_node()->get_transformer<wf::pixdecor::pixdecor_shade>(
+                    view->get_transformed_node()->get_transformer<pixdecor_shade>(
                         shade_transformer_name))
             {
                 tr->set_titlebar_height(titlebar_height);
@@ -259,9 +263,9 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             if (auto toplevel = wf::toplevel_cast(view))
             {
                 bool direction = true;
-                auto deco = toplevel->toplevel()->get_data<wf::simple_decorator_t>();
+                auto deco = toplevel->toplevel()->get_data<simple_decorator_t>();
                 if (auto tr =
-                        view->get_transformed_node()->get_transformer<wf::pixdecor::pixdecor_shade>(
+                        view->get_transformed_node()->get_transformer<pixdecor_shade>(
                             shade_transformer_name))
                 {
                     direction = !tr->get_direction();
@@ -282,7 +286,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             {
                 if (auto toplevel = wf::toplevel_cast(v))
                 {
-                    auto deco = toplevel->toplevel()->get_data<wf::simple_decorator_t>();
+                    auto deco = toplevel->toplevel()->get_data<simple_decorator_t>();
                     init_shade(v, ev->delta < 0 ? true : false,
                         deco ? deco->get_titlebar_height() : csd_titlebar_height);
                     return true;
@@ -312,13 +316,13 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 if (auto tr =
-                        view->get_transformed_node()->get_transformer<wf::pixdecor::pixdecor_shade>(
+                        view->get_transformed_node()->get_transformer<pixdecor_shade>(
                             shade_transformer_name))
                 {
                     auto toplevel = toplevel_cast(view);
                     if (toplevel)
                     {
-                        if (!toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                        if (!toplevel->toplevel()->get_data<simple_decorator_t>())
                         {
                             tr->set_titlebar_height(csd_titlebar_height);
                         }
@@ -337,7 +341,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 auto toplevel = wf::toplevel_cast(view);
-                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>())
                 {
                     continue;
                 }
@@ -390,12 +394,12 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 auto toplevel = wf::toplevel_cast(view);
-                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>())
                 {
                     continue;
                 }
 
-                auto deco = toplevel->toplevel()->get_data<wf::simple_decorator_t>();
+                auto deco = toplevel->toplevel()->get_data<simple_decorator_t>();
                 deco->update_animation();
             }
         };
@@ -439,7 +443,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 auto toplevel = wf::toplevel_cast(view);
-                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>())
                 {
                     continue;
                 }
@@ -452,7 +456,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 auto toplevel = wf::toplevel_cast(view);
-                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>())
                 {
                     continue;
                 }
@@ -466,7 +470,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 auto toplevel = wf::toplevel_cast(view);
-                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>() ||
+                if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>() ||
                     !toplevel->pending_tiled_edges())
                 {
                     continue;
@@ -483,7 +487,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 auto toplevel = wf::toplevel_cast(view);
-                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>() ||
+                if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>() ||
                     !toplevel->pending_tiled_edges())
                 {
                     continue;
@@ -538,6 +542,10 @@ class wayfire_pixdecor : public wf::plugin_interface_t
 
         on_output_added.disconnect();
         on_output_removed.disconnect();
+        on_decoration_state_changed.disconnect();
+        on_new_tx.disconnect();
+        on_app_id_changed.disconnect();
+        on_title_changed.disconnect();
 
         wf::get_core().bindings->rem_binding(&shade_axis_cb);
         remove_shade_transformers();
@@ -550,7 +558,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
 
     void recreate_frame(wayfire_toplevel_view toplevel)
     {
-        auto deco = toplevel->toplevel()->get_data<wf::simple_decorator_t>();
+        auto deco = toplevel->toplevel()->get_data<simple_decorator_t>();
         if (!deco)
         {
             return;
@@ -604,7 +612,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             for (auto& view : wf::get_core().get_all_views())
             {
                 auto toplevel = wf::toplevel_cast(view);
-                if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+                if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>())
                 {
                     continue;
                 }
@@ -620,13 +628,13 @@ class wayfire_pixdecor : public wf::plugin_interface_t
         for (auto& view : wf::get_core().get_all_views())
         {
             auto toplevel = wf::toplevel_cast(view);
-            if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+            if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>())
             {
                 continue;
             }
 
             view->damage();
-            toplevel->toplevel()->get_data<wf::simple_decorator_t>()->effect_updated();
+            toplevel->toplevel()->get_data<simple_decorator_t>()->effect_updated();
 
             auto& pending = toplevel->toplevel()->pending();
             if (!resize_decorations || (pending.tiled_edges != 0))
@@ -644,7 +652,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
             } else
             {
                 pending.geometry = wf::shrink_geometry_by_margins(pending.geometry, pending.margins);
-                pending.margins  = toplevel->toplevel()->get_data<wf::simple_decorator_t>()->get_margins(
+                pending.margins  = toplevel->toplevel()->get_data<simple_decorator_t>()->get_margins(
                     toplevel->toplevel()->pending());
                 pending.geometry = wf::expand_geometry_by_margins(pending.geometry, pending.margins);
             }
@@ -658,12 +666,12 @@ class wayfire_pixdecor : public wf::plugin_interface_t
         for (auto& view : wf::get_core().get_all_views())
         {
             auto toplevel = wf::toplevel_cast(view);
-            if (!toplevel || !toplevel->toplevel()->get_data<wf::simple_decorator_t>())
+            if (!toplevel || !toplevel->toplevel()->get_data<simple_decorator_t>())
             {
                 continue;
             }
 
-            auto deco = toplevel->toplevel()->get_data<wf::simple_decorator_t>();
+            auto deco = toplevel->toplevel()->get_data<simple_decorator_t>();
             deco->update_colors();
             view->damage();
         }
@@ -691,12 +699,12 @@ class wayfire_pixdecor : public wf::plugin_interface_t
     {
         auto toplevel = view->toplevel();
 
-        if (!toplevel->get_data<wf::simple_decorator_t>())
+        if (!toplevel->get_data<simple_decorator_t>())
         {
-            toplevel->store_data(std::make_unique<wf::simple_decorator_t>(view));
+            toplevel->store_data(std::make_unique<simple_decorator_t>(view));
         }
 
-        auto deco     = toplevel->get_data<wf::simple_decorator_t>();
+        auto deco     = toplevel->get_data<simple_decorator_t>();
         auto& pending = toplevel->pending();
         pending.margins = deco->get_margins(pending);
 
@@ -709,7 +717,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
 
     void remove_decoration(wayfire_toplevel_view view)
     {
-        view->toplevel()->erase_data<wf::simple_decorator_t>();
+        view->toplevel()->erase_data<simple_decorator_t>();
         auto& pending = view->toplevel()->pending();
         if (!pending.fullscreen && !pending.tiled_edges)
         {
@@ -734,10 +742,10 @@ class wayfire_pixdecor : public wf::plugin_interface_t
                 return;
             }
 
-            if (!toplevel->toplevel()->get_data<wf::simple_decorator_t>() && (always_decorate.matches(view) ||
-                                                                              (should_decorate_view(toplevel)
-                                                                               &&
-                                                                               !ignore_views.matches(view))))
+            if (!toplevel->toplevel()->get_data<simple_decorator_t>() && (always_decorate.matches(view) ||
+                                                                          (should_decorate_view(toplevel)
+                                                                           &&
+                                                                           !ignore_views.matches(view))))
             {
                 adjust_new_decorations(toplevel);
             } else if ((!always_decorate.matches(view) &&
@@ -750,5 +758,7 @@ class wayfire_pixdecor : public wf::plugin_interface_t
         }
     }
 };
+}
+}
 
-DECLARE_WAYFIRE_PLUGIN(wayfire_pixdecor);
+DECLARE_WAYFIRE_PLUGIN(wf::pixdecor::wayfire_pixdecor);

--- a/src/shade.hpp
+++ b/src/shade.hpp
@@ -30,7 +30,7 @@ class shade_animation_t : public duration_t
 };
 class pixdecor_shade : public wf::scene::view_2d_transformer_t
 {
-    nonstd::observer_ptr<wf::simple_decorator_t> deco = nullptr;
+    nonstd::observer_ptr<simple_decorator_t> deco = nullptr;
     wayfire_view view;
     wf::output_t *output;
     int titlebar_height;
@@ -133,7 +133,7 @@ class pixdecor_shade : public wf::scene::view_2d_transformer_t
 
         if (auto toplevel = wf::toplevel_cast(view))
         {
-            this->deco = toplevel->toplevel()->get_data<wf::simple_decorator_t>();
+            this->deco = toplevel->toplevel()->get_data<simple_decorator_t>();
         }
     }
 


### PR DESCRIPTION
This fixes hotswapping pixdecor and default wayfire decoration plugins.