### PR TITLE
BUGFIX: fix massive memory leak in `wf::pixdecor::pixdecor_theme_t::get_font_description()`

### DIFF
--- a/src/deco-theme.hpp
+++ b/src/deco-theme.hpp
@@ -48,7 +48,7 @@ class pixdecor_theme_t
      * @param fb The target framebuffer, must have been bound already.
      * @param rectangle The rectangle to redraw.
      * @param scissor The GL scissor rectangle to use.
-     * @param active Whether to use active or inactive colorse
+     * @param active Whether to use active or inactive colors
      */
     void render_background(const wf::scene::render_instruction_t& data,
         wf::geometry_t rectangle, bool active, wf::pointf_t p);

--- a/src/deco-theme.hpp
+++ b/src/deco-theme.hpp
@@ -38,7 +38,7 @@ class pixdecor_theme_t
     int get_input_size() const;
     /** @return The decoration color */
     wf::color_t get_decor_color(bool active) const;
-    std::unique_ptr<PangoFontDescription*> get_font_description();
+    std::unique_ptr<PangoFontDescription, decltype(&pango_font_description_free)> get_font_description();
 
     void update_colors(void);
 
@@ -48,7 +48,7 @@ class pixdecor_theme_t
      * @param fb The target framebuffer, must have been bound already.
      * @param rectangle The rectangle to redraw.
      * @param scissor The GL scissor rectangle to use.
-     * @param active Whether to use active or inactive colors
+     * @param active Whether to use active or inactive colorse
      */
     void render_background(const wf::scene::render_instruction_t& data,
         wf::geometry_t rectangle, bool active, wf::pointf_t p);
@@ -92,7 +92,7 @@ class pixdecor_theme_t
     wf::color_t fg_text;
     wf::color_t bg_text;
     bool maximized;
-    std::unique_ptr<PangoFontDescription*> font_description;
+    std::unique_ptr<PangoFontDescription, decltype(&pango_font_description_free)> font_description;
 };
 }
 }


### PR DESCRIPTION
Signed-off-by: kernaltrap <kernaltrap@gmail.com>

A PangoFontDescription* object was being wrapped in a `unique_ptr` and not properly free'd. The pointer was free'd, but not the object. This fixes all of the visible leaks I can see in wayfire, other than leaks from `libgallium`.
For reference, this is Heaptrack before and after the patch:
Before: 
<img width="1917" height="541" alt="image" src="https://github.com/user-attachments/assets/ada16dd4-4597-411c-87aa-15e64b376c08" />
After:
<img width="1619" height="785" alt="image" src="https://github.com/user-attachments/assets/6ff3289d-c2c0-4376-9e15-b578b14dbeab" />
The first image is from a Heaptrack recorded over the course of 22 hours, the second is after 40 minutes or so. May not be super accurate, but I'm fairly certain this leak is gone because resizing windows did not cause any pixdecor functions to show up in Heaptrack.